### PR TITLE
Contributor simple

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -11,5 +11,5 @@
   <component name="PDMPlugin">
     <option name="skipTestSources" value="false" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_20" default="true" project-jdk-name="temurin-20" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_X" default="true" project-jdk-name="temurin-20" project-jdk-type="JavaSDK" />
 </project>

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ApiVersionsMarkingFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ApiVersionsMarkingFilter.java
@@ -41,11 +41,16 @@ public class ApiVersionsMarkingFilter implements RequestFilter {
         });
     }
 
-    public static class Contributor implements FilterContributor {
+    public static class Contributor implements FilterContributor<BaseConfig> {
 
         @Override
         public String getTypeName() {
             return "ApiVersionsMarkingFilter";
+        }
+
+        @Override
+        public Class<BaseConfig> getConfigClass() {
+            return BaseConfig.class;
         }
 
         @Override

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
@@ -503,11 +503,16 @@ public class MultiTenantTransformationFilter
     public MultiTenantTransformationFilter() {
     }
 
-    public static class Contributor implements FilterContributor {
+    public static class Contributor implements FilterContributor<BaseConfig> {
 
         @Override
         public String getTypeName() {
             return "MultiTenant";
+        }
+
+        @Override
+        public Class<BaseConfig> getConfigClass() {
+            return BaseConfig.class;
         }
 
         @Override

--- a/kroxylicious-additional-filters/kroxylicious-schema-validation/src/test/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributorTest.java
+++ b/kroxylicious-additional-filters/kroxylicious-schema-validation/src/test/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributorTest.java
@@ -20,7 +20,7 @@ import io.kroxylicious.proxy.filter.schema.config.ValidationConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ProduceRequestValidationFilterContributorTest {
+class ProduceRequestValidationFilterFactoryTest {
     private static final TypeReference<Map<String, Object>> MAP_REF = new TypeReference<>() {
     };
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
@@ -14,6 +14,10 @@ public interface FilterContributor<C extends BaseConfig> {
 
     String getTypeName();
 
+    default Class getFilterType() {
+        return Object.class;
+    }
+
     Class<C> getConfigClass();
 
     /**

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
@@ -8,15 +8,13 @@ package io.kroxylicious.proxy.filter;
 import io.kroxylicious.proxy.config.BaseConfig;
 
 /**
- * FilterContributor is a pluggable source of Kroxylicious filter implementations.
+ * A FilterContributor is a factory for a filter implementation.
  */
-public interface FilterContributor {
+public interface FilterContributor<C extends BaseConfig> {
 
     String getTypeName();
 
-    default Class<? extends BaseConfig> getConfigClass() {
-        return BaseConfig.class;
-    }
+    Class<C> getConfigClass();
 
     /**
      * Creates an instance of the service.
@@ -24,6 +22,6 @@ public interface FilterContributor {
      * @param context   context containing service configuration which may be null if the service instance does not accept configuration.
      * @return the service instance, or null if this contributor does not offer this short name.
      */
-    Filter getInstance(BaseConfig config, FilterConstructContext context);
+    Filter getInstance(C config, FilterConstructContext context);
 
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/config/ProxyConfigLoader.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/config/ProxyConfigLoader.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.config;
+
+import java.util.ServiceLoader;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.filter.FilterContributor;
+import io.kroxylicious.proxy.internal.config.model.ProxyConfig;
+
+public class ProxyConfigLoader {
+    /*
+     * adminHttp:
+     * endpoints:
+     * prometheus: {}
+     * virtualClusters:
+     * demo:
+     * targetCluster:
+     * bootstrap_servers: localhost:9092
+     * clusterNetworkAddressConfigProvider:
+     * type: PortPerBroker
+     * config:
+     * bootstrapAddress: localhost:9192
+     * logNetwork: false
+     * logFrames: false
+     * filters:
+     * fromDirectory: "filters.d"
+     * fromTopic:
+     * fromTopic:
+     * consumerConfig:
+     */
+
+    /*
+     * And them the filters are like files like 10-ReplaceFooWithBar.yml
+     * type: org.example.SampleProduceRequest
+     * config:
+     * findValue: foo
+     * replacementValue: bar
+     *
+     */
+
+    public static void main(String[] args) throws JsonProcessingException {
+        YAMLMapper mapper = new YAMLMapper();
+
+        // We load the config file
+        // Note that filters is not literal, but supports a number of sources
+        // We can implment support for loading filters from a .d directory, in classic unix style
+        // Or we can just read from a Kafka Topic (which makes is easier to do dynamic reconfig in a container env)
+        var pc = mapper.readValue("""
+                adminHttp:
+                  endpoints:
+                    prometheus: "{}"
+
+                filters:
+                  fromDirectory: "filters.d"
+                """, ProxyConfig.class);
+
+        // We then load each of the filters. Here's an example file/record value
+        var tree = mapper.readTree("""
+                type: io.kroxylicious.proxy.internal.filter.FetchResponseTransformationFilter
+                # type is the FQ class name. Maybe we support the unqualified class name for conventience, like Kafka Connect, but it's always based on the class name
+                # and not something the filter class itself is able to override
+                config:
+                  transformation: io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter$UpperCasing""");
+        var filterClassName = tree.get("type").asText();
+
+        // We load the services. If we support filter isolation here we need to use the load() override which takes a classloader
+        var services = ServiceLoader.load(FilterContributor.class);
+
+        // The FilterContributor has a getFilterType method that returns the Class of the filters it constructs
+        // We use this to find a match for a given filter YAML
+        var contributor = services.stream()
+                .map(ServiceLoader.Provider::get)
+                .filter(fc -> {
+                    return fc.getFilterType().getName().equals(filterClassName);
+                }).findFirst().get();
+
+        // We convert the TreeNode for the `config` part of the YAML to the Java config representation
+        Class configClass = contributor.getConfigClass();
+        var config = (BaseConfig) mapper.treeToValue(tree.get("config"), configClass);
+        // Note AFAICS there's not need for BaseConfig here at all
+
+        // We instantiate a filter
+        contributor.getInstance(config, null);
+
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/config/model/AdminHttp.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/config/model/AdminHttp.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.config.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AdminHttp(@JsonProperty AdminHttpEndpoints endpoints) {}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/config/model/AdminHttpEndpoints.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/config/model/AdminHttpEndpoints.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.config.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AdminHttpEndpoints(@JsonProperty String prometheus) {}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/config/model/FilterSource.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/config/model/FilterSource.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.config.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record FilterSource(
+                           @JsonProperty String fromDirectory,
+                           @JsonProperty String fromTopic) {
+
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/config/model/ProxyConfig.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/config/model/ProxyConfig.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.config.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ProxyConfig(
+                          @JsonProperty AdminHttp adminHttp,
+                          // @JsonProperty VirtualClusters vitrualClusters,
+                          @JsonProperty FilterSource filters) {}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
@@ -30,6 +30,9 @@ import org.apache.kafka.common.record.TimestampType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.filter.FetchResponseFilter;
 import io.kroxylicious.proxy.filter.Filter;
@@ -48,7 +51,8 @@ public class FetchResponseTransformationFilter implements FetchResponseFilter {
 
         private final String transformation;
 
-        public FetchResponseTransformationConfig(String transformation) {
+        @JsonCreator
+        public FetchResponseTransformationConfig(@JsonProperty("transformation") String transformation) {
             this.transformation = transformation;
         }
 
@@ -134,7 +138,11 @@ public class FetchResponseTransformationFilter implements FetchResponseFilter {
         }
     }
 
-    public static class Contributor implements FilterContributor {
+    public static class Contributor implements FilterContributor<FetchResponseTransformationConfig> {
+        @Override
+        public Class getFilterType() {
+            return FetchResponseTransformationFilter.class;
+        }
 
         @Override
         public String getTypeName() {
@@ -142,12 +150,12 @@ public class FetchResponseTransformationFilter implements FetchResponseFilter {
         }
 
         @Override
-        public Class<? extends BaseConfig> getConfigClass() {
+        public Class<FetchResponseTransformationConfig> getConfigClass() {
             return FetchResponseTransformationConfig.class;
         }
 
         @Override
-        public Filter getInstance(BaseConfig config, FilterConstructContext context) {
+        public Filter getInstance(FetchResponseTransformationConfig config, FilterConstructContext context) {
             return new FetchResponseTransformationFilter((FetchResponseTransformationConfig) config);
         }
     }


### PR DESCRIPTION
Hi @robobario, I hacked a bit more on this mainly to get straighter in my head how we go from config file + classes on classpath to a filter instance.  

I think I'd:

* Get rid of `FilterContributor.getTypeName()` -- if we want to support aliases we can do that using just the unqualified class name of the Filter, no need to let filter authors override it.
* Add `FilterContributor.getConfigClass()` to make is easier to convert from the `filter.confg` YAML object to the Java config instance
* Make `FilterContributor` generic in the config class to help enforce consistency between `getConfigClass()` and `getInstance`
* Split out where exactly the filters come from in the proxy YAML. This one is not really a core part of this change to how the Contributor works, but I think is an idea worth exploring. Consuming from a topic makes it easier to dynamically reconfigure a running instance...

Hopefully you get the idea. I haven't waded too much into actually refactoring the FilterContributorManager. to use this model yet.  I did this mostly for discussion purposes.