### PR TITLE
Old broker test

### DIFF
--- a/kroxylicious-app/src/main/java/io/kroxylicious/app/Kroxylicious.java
+++ b/kroxylicious-app/src/main/java/io/kroxylicious/app/Kroxylicious.java
@@ -10,12 +10,12 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.Properties;
 import java.util.concurrent.Callable;
-import java.util.function.BiFunction;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.proxy.KafkaProxy;
+import io.kroxylicious.proxy.ProxyEnvironment;
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
@@ -35,13 +35,18 @@ public class Kroxylicious implements Callable<Integer> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("io.kroxylicious.proxy.StartupShutdownLogger");
     private static final String UNKNOWN = "unknown";
-    private final BiFunction<PluginFactoryRegistry, Configuration, KafkaProxy> proxyBuilder;
+    public static final String KROXYLICIOUS_ENVIRONMENT = "KROXYLICIOUS_ENVIRONMENT";
+    private final KafkaProxyBuilder proxyBuilder;
+
+    interface KafkaProxyBuilder {
+        KafkaProxy build(PluginFactoryRegistry registry, Configuration config, ProxyEnvironment environment);
+    }
 
     Kroxylicious() {
         this(KafkaProxy::new);
     }
 
-    Kroxylicious(BiFunction<PluginFactoryRegistry, Configuration, KafkaProxy> proxyBuilder) {
+    Kroxylicious(KafkaProxyBuilder proxyBuilder) {
         this.proxyBuilder = proxyBuilder;
     }
 
@@ -61,8 +66,9 @@ public class Kroxylicious implements Callable<Integer> {
         try (InputStream stream = Files.newInputStream(configFile.toPath())) {
 
             Configuration config = configParser.parseConfiguration(stream);
-            printBannerAndVersions();
-            try (KafkaProxy kafkaProxy = proxyBuilder.apply(configParser, config)) {
+            ProxyEnvironment proxyEnvironment = getEnvironment();
+            printBannerAndVersions(proxyEnvironment);
+            try (KafkaProxy kafkaProxy = proxyBuilder.build(configParser, config, proxyEnvironment)) {
                 kafkaProxy.startup();
                 kafkaProxy.block();
             }
@@ -75,11 +81,21 @@ public class Kroxylicious implements Callable<Integer> {
         return 0;
     }
 
-    private static void printBannerAndVersions() throws Exception {
+    private static ProxyEnvironment getEnvironment() {
+        String environmentString = System.getProperty(KROXYLICIOUS_ENVIRONMENT,
+                System.getenv().getOrDefault(KROXYLICIOUS_ENVIRONMENT, ProxyEnvironment.PRODUCTION.name()));
+        return ProxyEnvironment.valueOf(environmentString);
+    }
+
+    private static void printBannerAndVersions(ProxyEnvironment proxyEnvironment) throws Exception {
         new BannerLogger().log();
         String[] versions = new VersionProvider().getVersion();
         for (String version : versions) {
             LOGGER.info("{}", version);
+        }
+        LOGGER.info("environment: " + proxyEnvironment.name());
+        if (proxyEnvironment == ProxyEnvironment.DEVELOPMENT) {
+            LOGGER.warn("Warning, kroxylicious is configured for development. The proxy is permitted to apply some features that are for testing only.");
         }
         LOGGER.atInfo()
                 .setMessage("Platform: Java {}({}) running on {} {}/{}")

--- a/kroxylicious-app/src/main/java/io/kroxylicious/app/Kroxylicious.java
+++ b/kroxylicious-app/src/main/java/io/kroxylicious/app/Kroxylicious.java
@@ -93,7 +93,7 @@ public class Kroxylicious implements Callable<Integer> {
         for (String version : versions) {
             LOGGER.info("{}", version);
         }
-        LOGGER.info("environment: " + proxyEnvironment.name());
+        LOGGER.info("environment: {}", proxyEnvironment.name());
         if (proxyEnvironment == ProxyEnvironment.DEVELOPMENT) {
             LOGGER.warn("Warning, kroxylicious is configured for development. The proxy is permitted to apply some features that are for testing only.");
         }

--- a/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
+++ b/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
@@ -64,7 +64,7 @@ class KroxyliciousIT {
         assertThat(lastProcess.onExit()).succeedsWithin(5, TimeUnit.SECONDS);
         byte[] bytes = lastProcess.getInputStream().readAllBytes();
         String output = new String(bytes, StandardCharsets.UTF_8);
-        assertThat(output).contains("internal configuration for proxy present in production mode");
+        assertThat(output).contains("internal configuration for proxy present in production environment");
         tester.close();
     }
 
@@ -79,7 +79,7 @@ class KroxyliciousIT {
         assertThat(lastProcess.onExit()).succeedsWithin(5, TimeUnit.SECONDS);
         byte[] bytes = lastProcess.getInputStream().readAllBytes();
         String output = new String(bytes, StandardCharsets.UTF_8);
-        assertThat(output).contains("internal configuration for proxy present in production mode");
+        assertThat(output).contains("internal configuration for proxy present in production environment");
         tester.close();
     }
 

--- a/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
+++ b/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
@@ -6,32 +6,40 @@
 package io.kroxylicious.app;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
+import io.kroxylicious.proxy.ProxyEnvironment;
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.Configuration;
-import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.newBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -43,11 +51,76 @@ class KroxyliciousIT {
     private static final String TOPIC_1 = "my-test-topic";
     private static final String TOPIC_2 = "other-test-topic";
     private static final String PLAINTEXT = "Hello, world!";
+    private static final ProxyEnvironment DEFAULT_ENV = ProxyEnvironment.PRODUCTION;
+
+    @Test
+    void shouldFailToStartWithInternalConfigurationsByDefault(@TempDir Path tempDir) throws IOException {
+        SubprocessKroxyliciousFactory kroxyliciousFactory = new SubprocessKroxyliciousFactory(tempDir, (environment, processBuilder) -> {
+            // no-op so that io is not inherited
+        }, List.of());
+        var tester = kroxyliciousTester(proxy("fake:9092").withExperimental(Map.of("a", "b")), kroxyliciousFactory);
+        Process lastProcess = kroxyliciousFactory.lastProcess;
+        assertThat(lastProcess).isNotNull();
+        assertThat(lastProcess.onExit()).succeedsWithin(5, TimeUnit.SECONDS);
+        byte[] bytes = lastProcess.getInputStream().readAllBytes();
+        String output = new String(bytes, StandardCharsets.UTF_8);
+        assertThat(output).contains("experimental configuration for proxy present in production mode");
+        tester.close();
+    }
+
+    @Test
+    void shouldFailToStartInExplicitProductionEnvironmentWithInternalConfigurations(@TempDir Path tempDir) throws IOException {
+        SubprocessKroxyliciousFactory kroxyliciousFactory = new SubprocessKroxyliciousFactory(tempDir, (environment, processBuilder) -> {
+            processBuilder.environment().put(Kroxylicious.KROXYLICIOUS_ENVIRONMENT, environment.name());
+        }, List.of());
+        var tester = kroxyliciousTester(proxy("fake:9092").withExperimental(Map.of("a", "b")), kroxyliciousFactory);
+        Process lastProcess = kroxyliciousFactory.lastProcess;
+        assertThat(lastProcess).isNotNull();
+        assertThat(lastProcess.onExit()).succeedsWithin(5, TimeUnit.SECONDS);
+        byte[] bytes = lastProcess.getInputStream().readAllBytes();
+        String output = new String(bytes, StandardCharsets.UTF_8);
+        assertThat(output).contains("experimental configuration for proxy present in production mode");
+        tester.close();
+    }
+
+    @Test
+    void shouldStartInDevelopmentEnvironmentWithInternalConfigurationEnvVar(KafkaCluster cluster, Admin admin, @TempDir Path tempDir) throws Exception {
+        admin.createTopics(List.of(
+                new NewTopic(TOPIC_1, 1, (short) 1),
+                new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
+
+        try (var tester = newBuilder(proxy(cluster).withExperimental(Map.of("a", "b")))
+                .setKroxyliciousFactory(new SubprocessKroxyliciousFactory(tempDir))
+                .setEnvironment(ProxyEnvironment.DEVELOPMENT)
+                .createDefaultKroxyliciousTester();
+                var producer = tester.producer(Map.of(
+                        ProducerConfig.CLIENT_ID_CONFIG, "shouldModifyProduceMessage",
+                        ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
+                var consumer = tester.consumer()) {
+            assertProxies(producer, consumer);
+        }
+    }
+
+    @Test
+    void shouldStartInDevelopmentEnvironmentWithInternalConfigurationSystemProp(KafkaCluster cluster, Admin admin, @TempDir Path tempDir) throws Exception {
+        admin.createTopics(List.of(
+                new NewTopic(TOPIC_1, 1, (short) 1),
+                new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
+
+        try (var tester = newBuilder(proxy(cluster).withExperimental(Map.of("a", "b")))
+                .setKroxyliciousFactory(new SubprocessKroxyliciousFactory(tempDir, (environment, processBuilder) -> processBuilder.inheritIO(),
+                        List.of("-D" + Kroxylicious.KROXYLICIOUS_ENVIRONMENT + "=" + ProxyEnvironment.DEVELOPMENT)))
+                .createDefaultKroxyliciousTester();
+                var producer = tester.producer(Map.of(
+                        ProducerConfig.CLIENT_ID_CONFIG, "shouldModifyProduceMessage",
+                        ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
+                var consumer = tester.consumer()) {
+            assertProxies(producer, consumer);
+        }
+    }
 
     @Test
     void shouldProxyWhenRunAsStandaloneProcess(KafkaCluster cluster, Admin admin, @TempDir Path tempDir) throws Exception {
-        var proxyAddress = HostPort.parse("localhost:9192");
-
         admin.createTopics(List.of(
                 new NewTopic(TOPIC_1, 1, (short) 1),
                 new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
@@ -57,36 +130,66 @@ class KroxyliciousIT {
                         ProducerConfig.CLIENT_ID_CONFIG, "shouldModifyProduceMessage",
                         ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
                 var consumer = tester.consumer()) {
-            producer.send(new ProducerRecord<>(TOPIC_1, "my-key", PLAINTEXT)).get();
-            producer.send(new ProducerRecord<>(TOPIC_2, "my-key", PLAINTEXT)).get();
-            producer.flush();
-
-            consumer.subscribe(Set.of(TOPIC_1));
-            ConsumerRecords<String, String> records1 = consumer.poll(Duration.ofSeconds(10));
-            consumer.subscribe(Set.of(TOPIC_2));
-            ConsumerRecords<String, String> records2 = consumer.poll(Duration.ofSeconds(10));
-
-            assertEquals(1, records1.count());
-            assertEquals(PLAINTEXT, records1.iterator().next().value());
-            assertEquals(1, records2.count());
-            assertEquals(PLAINTEXT, records2.iterator().next().value());
+            assertProxies(producer, consumer);
         }
     }
 
-    private record SubprocessKroxyliciousFactory(Path tempDir) implements Function<Configuration, AutoCloseable> {
+    private static void assertProxies(Producer<String, String> producer, Consumer<String, String> consumer)
+            throws InterruptedException, ExecutionException {
+        producer.send(new ProducerRecord<>(KroxyliciousIT.TOPIC_1, "my-key", KroxyliciousIT.PLAINTEXT)).get();
+        producer.send(new ProducerRecord<>(KroxyliciousIT.TOPIC_2, "my-key", KroxyliciousIT.PLAINTEXT)).get();
+        producer.flush();
+
+        consumer.subscribe(Set.of(KroxyliciousIT.TOPIC_1));
+        ConsumerRecords<String, String> records1 = consumer.poll(Duration.ofSeconds(10));
+        consumer.subscribe(Set.of(KroxyliciousIT.TOPIC_2));
+        ConsumerRecords<String, String> records2 = consumer.poll(Duration.ofSeconds(10));
+
+        assertEquals(1, records1.count());
+        assertEquals(KroxyliciousIT.PLAINTEXT, records1.iterator().next().value());
+        assertEquals(1, records2.count());
+        assertEquals(KroxyliciousIT.PLAINTEXT, records2.iterator().next().value());
+    }
+
+    private static class SubprocessKroxyliciousFactory implements BiFunction<ProxyEnvironment, Configuration, AutoCloseable> {
+
+        private final Path tempDir;
+        private final java.util.function.BiConsumer<ProxyEnvironment, ProcessBuilder> processBuilderModifier;
+        private final List<String> jvmArgs;
+        private Process lastProcess;
+
+        SubprocessKroxyliciousFactory(Path tempDir) {
+            this(tempDir, (env, processBuilder) -> {
+                processBuilder.inheritIO();
+                if (env != DEFAULT_ENV) {
+                    processBuilder.environment().put(Kroxylicious.KROXYLICIOUS_ENVIRONMENT, env.name());
+                }
+            }, List.of());
+        }
+
+        SubprocessKroxyliciousFactory(Path tempDir, java.util.function.BiConsumer<ProxyEnvironment, ProcessBuilder> processBuilderModifier, List<String> jvmArgs) {
+            this.tempDir = tempDir;
+            this.processBuilderModifier = processBuilderModifier;
+            this.jvmArgs = jvmArgs;
+        }
 
         @Override
-        public AutoCloseable apply(Configuration config) {
+        public AutoCloseable apply(ProxyEnvironment environment, Configuration config) {
             try {
                 Path configPath = tempDir.resolve("config.yaml");
                 Files.writeString(configPath, new ConfigParser().toYaml(config));
                 String java = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
                 String classpath = System.getProperty("java.class.path");
-                var processBuilder = new ProcessBuilder(java, "-cp", classpath, "io.kroxylicious.app.Kroxylicious", "-c", configPath.toString()).inheritIO();
-                Process start = processBuilder.start();
+                List<String> command = new ArrayList<>();
+                command.add(java);
+                command.addAll(jvmArgs);
+                command.addAll(List.of("-cp", classpath, "io.kroxylicious.app.Kroxylicious", "-c", configPath.toString()));
+                var processBuilder = new ProcessBuilder(command);
+                processBuilderModifier.accept(environment, processBuilder);
+                lastProcess = processBuilder.start();
                 return () -> {
-                    start.destroy();
-                    start.onExit().get(10, TimeUnit.SECONDS);
+                    lastProcess.destroy();
+                    lastProcess.onExit().get(10, TimeUnit.SECONDS);
                 };
             }
             catch (Exception e) {

--- a/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
+++ b/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
@@ -58,13 +58,13 @@ class KroxyliciousIT {
         SubprocessKroxyliciousFactory kroxyliciousFactory = new SubprocessKroxyliciousFactory(tempDir, (environment, processBuilder) -> {
             // no-op so that io is not inherited
         }, List.of());
-        var tester = kroxyliciousTester(proxy("fake:9092").withExperimental(Map.of("a", "b")), kroxyliciousFactory);
+        var tester = kroxyliciousTester(proxy("fake:9092").withInternal(Map.of("a", "b")), kroxyliciousFactory);
         Process lastProcess = kroxyliciousFactory.lastProcess;
         assertThat(lastProcess).isNotNull();
         assertThat(lastProcess.onExit()).succeedsWithin(5, TimeUnit.SECONDS);
         byte[] bytes = lastProcess.getInputStream().readAllBytes();
         String output = new String(bytes, StandardCharsets.UTF_8);
-        assertThat(output).contains("experimental configuration for proxy present in production mode");
+        assertThat(output).contains("internal configuration for proxy present in production mode");
         tester.close();
     }
 
@@ -73,13 +73,13 @@ class KroxyliciousIT {
         SubprocessKroxyliciousFactory kroxyliciousFactory = new SubprocessKroxyliciousFactory(tempDir, (environment, processBuilder) -> {
             processBuilder.environment().put(Kroxylicious.KROXYLICIOUS_ENVIRONMENT, environment.name());
         }, List.of());
-        var tester = kroxyliciousTester(proxy("fake:9092").withExperimental(Map.of("a", "b")), kroxyliciousFactory);
+        var tester = kroxyliciousTester(proxy("fake:9092").withInternal(Map.of("a", "b")), kroxyliciousFactory);
         Process lastProcess = kroxyliciousFactory.lastProcess;
         assertThat(lastProcess).isNotNull();
         assertThat(lastProcess.onExit()).succeedsWithin(5, TimeUnit.SECONDS);
         byte[] bytes = lastProcess.getInputStream().readAllBytes();
         String output = new String(bytes, StandardCharsets.UTF_8);
-        assertThat(output).contains("experimental configuration for proxy present in production mode");
+        assertThat(output).contains("internal configuration for proxy present in production mode");
         tester.close();
     }
 
@@ -89,7 +89,7 @@ class KroxyliciousIT {
                 new NewTopic(TOPIC_1, 1, (short) 1),
                 new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
 
-        try (var tester = newBuilder(proxy(cluster).withExperimental(Map.of("a", "b")))
+        try (var tester = newBuilder(proxy(cluster).withInternal(Map.of("a", "b")))
                 .setKroxyliciousFactory(new SubprocessKroxyliciousFactory(tempDir))
                 .setEnvironment(ProxyEnvironment.DEVELOPMENT)
                 .createDefaultKroxyliciousTester();
@@ -107,7 +107,7 @@ class KroxyliciousIT {
                 new NewTopic(TOPIC_1, 1, (short) 1),
                 new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
 
-        try (var tester = newBuilder(proxy(cluster).withExperimental(Map.of("a", "b")))
+        try (var tester = newBuilder(proxy(cluster).withInternal(Map.of("a", "b")))
                 .setKroxyliciousFactory(new SubprocessKroxyliciousFactory(tempDir, (environment, processBuilder) -> processBuilder.inheritIO(),
                         List.of("-D" + Kroxylicious.KROXYLICIOUS_ENVIRONMENT + "=" + ProxyEnvironment.DEVELOPMENT)))
                 .createDefaultKroxyliciousTester();

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/ResponsePayload.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/ResponsePayload.java
@@ -11,4 +11,11 @@ import org.apache.kafka.common.protocol.ApiMessage;
 
 public record ResponsePayload(ApiKeys apiKeys,
                               short apiVersion,
-                              ApiMessage message) {}
+                              ApiMessage message,
+                              short responseApiVersion) {
+
+    public ResponsePayload(ApiKeys apiKeys, short apiVersion, ApiMessage message) {
+        this(apiKeys, apiVersion, message, apiVersion);
+    }
+
+}

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClientHandler.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClientHandler.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 
-import io.kroxylicious.test.codec.DecodedRequestFrame;
+import io.kroxylicious.test.codec.RequestFrame;
 
 /**
  * Simple kafka handle capable of sending one or more requests to a server side.
@@ -23,7 +23,7 @@ import io.kroxylicious.test.codec.DecodedRequestFrame;
 public class KafkaClientHandler extends ChannelInboundHandlerAdapter {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaClientHandler.class);
 
-    private final Deque<DecodedRequestFrame<?>> queue = new ConcurrentLinkedDeque<>();
+    private final Deque<RequestFrame> queue = new ConcurrentLinkedDeque<>();
     private ChannelHandlerContext ctx;
 
     // Read/Mutated by the Netty thread only.
@@ -63,7 +63,7 @@ public class KafkaClientHandler extends ChannelInboundHandlerAdapter {
      * @param decodedRequestFrame request frame to send
      * @return future that will yield the response along with a sequenceNumber indicating the order it was received by the client.
      */
-    public CompletableFuture<SequencedResponse> sendRequest(DecodedRequestFrame<?> decodedRequestFrame) {
+    public CompletableFuture<SequencedResponse> sendRequest(RequestFrame decodedRequestFrame) {
         queue.addLast(decodedRequestFrame);
         processPendingWrites();
         return decodedRequestFrame.getResponseFuture();

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessor.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessor.java
@@ -7,12 +7,13 @@ package io.kroxylicious.test.codec;
 
 import java.nio.ByteBuffer;
 
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.protocol.Writable;
 
 /**
  * Provides write access to byte buffer for serializing frames.
  */
-public interface ByteBufAccessor extends Writable {
+public interface ByteBufAccessor extends Writable, Readable {
 
     @Override
     void writeByte(byte val);
@@ -56,4 +57,14 @@ public interface ByteBufAccessor extends Writable {
      */
     int writerIndex();
 
+    /**
+     * Get reader index
+     * @return readerIndex of underlying buffer
+     */
+    int readerIndex();
+
+    /**
+     * set reader index of underlying buffer
+     */
+    void readerIndex(int index);
 }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessorImpl.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessorImpl.java
@@ -7,8 +7,6 @@ package io.kroxylicious.test.codec;
 
 import java.nio.ByteBuffer;
 
-import org.apache.kafka.common.protocol.Readable;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 
@@ -21,7 +19,7 @@ import io.netty.buffer.ByteBufUtil;
  * depends on NIO ByteBuffer, so copying between ByteBuffer and ByteBuf cannot
  * always be avoided.
  */
-public class ByteBufAccessorImpl implements ByteBufAccessor, Readable {
+public class ByteBufAccessorImpl implements ByteBufAccessor {
 
     private final ByteBuf buf;
 
@@ -240,6 +238,16 @@ public class ByteBufAccessorImpl implements ByteBufAccessor, Readable {
     @Override
     public int writerIndex() {
         return buf.writerIndex();
+    }
+
+    @Override
+    public int readerIndex() {
+        return buf.readerIndex();
+    }
+
+    @Override
+    public void readerIndex(int index) {
+        buf.readerIndex(index);
     }
 
 }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/DecodedRequestFrame.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/DecodedRequestFrame.java
@@ -19,7 +19,7 @@ import io.kroxylicious.test.client.SequencedResponse;
  */
 public class DecodedRequestFrame<B extends ApiMessage>
         extends DecodedFrame<RequestHeaderData, B>
-        implements Frame {
+        implements RequestFrame {
 
     private final CompletableFuture<SequencedResponse> responseFuture = new CompletableFuture<>();
 
@@ -50,6 +50,7 @@ public class DecodedRequestFrame<B extends ApiMessage>
      * Whether the Kafka Client expects a response to this request
      * @return Whether the Kafka Client expects a response to this request
      */
+    @Override
     public boolean hasResponse() {
         return !(body instanceof ProduceRequest pr && pr.acks() == 0);
     }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestDecoder.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestDecoder.java
@@ -51,7 +51,6 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
         LOGGER.debug("{}: {} downstream correlation id: {}", ctx, apiKey, correlationId);
 
         RequestHeaderData header;
-        final ByteBufAccessorImpl accessor;
         var decodeRequest = true;
         LOGGER.debug("Decode {}/v{} request? {}", apiKey, apiVersion, decodeRequest);
         boolean decodeResponse = true;
@@ -61,13 +60,13 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
             log().trace("{}: headerVersion {}", ctx, headerVersion);
         }
         in.readerIndex(sof);
-        accessor = new ByteBufAccessorImpl(in);
-        header = readHeader(headerVersion, accessor);
+        ByteBufAccessorImpl acc = new ByteBufAccessorImpl(in);
+        header = readHeader(headerVersion, acc);
         if (log().isTraceEnabled()) {
             log().trace("{}: header: {}", ctx, header);
         }
         final Frame frame;
-        ApiMessage body = BodyDecoder.decodeRequest(apiKey, apiVersion, accessor);
+        ApiMessage body = BodyDecoder.decodeRequest(apiKey, apiVersion, acc);
         if (log().isTraceEnabled()) {
             log().trace("{}: body {}", ctx, body);
         }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestEncoder.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestEncoder.java
@@ -16,7 +16,7 @@ import io.kroxylicious.test.client.CorrelationManager;
 /**
  * Kafka Request Encoder
  */
-public class KafkaRequestEncoder extends KafkaMessageEncoder<DecodedRequestFrame<?>> {
+public class KafkaRequestEncoder extends KafkaMessageEncoder<RequestFrame> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaRequestEncoder.class);
 
@@ -36,7 +36,7 @@ public class KafkaRequestEncoder extends KafkaMessageEncoder<DecodedRequestFrame
     }
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, DecodedRequestFrame frame, ByteBuf out) throws Exception {
+    protected void encode(ChannelHandlerContext ctx, RequestFrame frame, ByteBuf out) throws Exception {
         super.encode(ctx, frame, out);
         if (frame.hasResponse()) {
             correlationManager.putBrokerRequest(frame.apiKey().id, frame.apiVersion(), frame.correlationId(), frame.getResponseFuture());

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/OpaqueRequestFrame.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/OpaqueRequestFrame.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.codec;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.buffer.ByteBuf;
+
+import io.kroxylicious.test.client.SequencedResponse;
+
+/**
+ * A frame in the Kafka protocol which has not been decoded.
+ * The wrapped buffer <strong>does not</strong> include the frame size prefix.
+ */
+public class OpaqueRequestFrame implements RequestFrame {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpaqueRequestFrame.class);
+
+    /**
+     * Number of bytes required for storing the frame length.
+     */
+    private static final int FRAME_SIZE_LENGTH = Integer.BYTES;
+
+    protected final int length;
+    protected final int correlationId;
+    /** The message buffer excluding the frame size, including the header and body. */
+    protected final ByteBuf buf;
+    private final boolean hasResponse;
+    private final CompletableFuture<SequencedResponse> responseFuture = new CompletableFuture<>();
+    private final ApiKeys apiKey;
+    private final short apiVersion;
+
+    /**
+     * @param buf The message buffer (excluding the frame size)
+     * @param correlationId The correlation id
+     * @param length The length of the frame within {@code buf}.
+     * @param hasResponse do we expect a response
+     */
+    public OpaqueRequestFrame(ByteBuf buf, int correlationId, int length, boolean hasResponse, ApiKeys apiKey, short apiVersion) {
+        this.length = length;
+        this.correlationId = correlationId;
+        this.buf = buf.asReadOnly();
+        this.apiKey = apiKey;
+        this.apiVersion = apiVersion;
+        if (buf.readableBytes() != length) {
+            throw new AssertionError("readable: " + buf.readableBytes() + " length: " + length);
+        }
+        this.hasResponse = hasResponse;
+    }
+
+    @Override
+    public int correlationId() {
+        return correlationId;
+    }
+
+    @Override
+    public int estimateEncodedSize() {
+        return FRAME_SIZE_LENGTH + length;
+    }
+
+    @Override
+    public void encode(ByteBufAccessor out) {
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("Writing {} with 4 byte length ({}) plus {} bytes from buffer {} to {}",
+                    getClass().getSimpleName(), length, buf.readableBytes(), buf, out);
+        }
+        out.ensureWritable(estimateEncodedSize());
+        out.writeInt(length);
+        byte[] bytes = new byte[length];
+        buf.readBytes(bytes);
+        out.writeByteArray(bytes);
+        buf.release();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" +
+                "length=" + length +
+                ", buf=" + buf +
+                ')';
+    }
+
+    @Override
+    public CompletableFuture<SequencedResponse> getResponseFuture() {
+        return responseFuture;
+    }
+
+    @Override
+    public boolean hasResponse() {
+        return hasResponse;
+    }
+
+    @Override
+    public ApiKeys apiKey() {
+        return apiKey;
+    }
+
+    @Override
+    public short apiVersion() {
+        return apiVersion;
+    }
+}

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/RequestFrame.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/RequestFrame.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.codec;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import io.kroxylicious.test.client.SequencedResponse;
+
+public interface RequestFrame extends Frame {
+
+    CompletableFuture<SequencedResponse> getResponseFuture();
+
+    /**
+     * Whether the Kafka Client expects a response to this request
+     * @return Whether the Kafka Client expects a response to this request
+     */
+    default boolean hasResponse() {
+        return true;
+    }
+
+    /**
+     * Get apiKey of body
+     * @return apiKey
+     */
+    ApiKeys apiKey();
+
+    /**
+     * Get apiVersion of frame
+     * @return apiKey
+     */
+    short apiVersion();
+
+}

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/Action.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/Action.java
@@ -23,10 +23,17 @@ interface Action {
     }
 
     static Action respond(ApiMessage message) {
-        return (ctx, frame) -> {
-            DecodedResponseFrame<?> responseFrame = new DecodedResponseFrame<>(frame.apiVersion(),
-                    frame.correlationId(), new ResponseHeaderData().setCorrelationId(frame.correlationId()), message);
-            ctx.write(responseFrame);
-        };
+        return (ctx, frame) -> writeResponse(message, ctx, frame, frame.apiVersion());
     }
+
+    static Action respond(ApiMessage message, short apiVersion) {
+        return (ctx, frame) -> writeResponse(message, ctx, frame, apiVersion);
+    }
+
+    private static void writeResponse(ApiMessage message, ChannelHandlerContext ctx, DecodedRequestFrame<?> frame, short apiVersion) {
+        DecodedResponseFrame<?> responseFrame = new DecodedResponseFrame<>(apiVersion,
+                frame.correlationId(), new ResponseHeaderData().setCorrelationId(frame.correlationId()), message);
+        ctx.write(responseFrame);
+    }
+
 }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockHandler.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockHandler.java
@@ -86,6 +86,7 @@ public class MockHandler extends ChannelInboundHandlerAdapter {
 
     /**
      * Set the response
+     *
      * @param response response
      */
     public void setMockResponseForApiKey(ApiKeys keys, ApiMessage response) {
@@ -100,6 +101,26 @@ public class MockHandler extends ChannelInboundHandlerAdapter {
                 description.appendText("has key " + keys);
             }
         }, Action.respond(response));
+    }
+
+    /**
+     * Set the response
+     *
+     * @param response response
+     * @param responseApiVersion apiVersion used to encode mock response
+     */
+    public void setMockResponseForApiKey(ApiKeys keys, ApiMessage response, short responseApiVersion) {
+        addMockResponse(new TypeSafeMatcher<>() {
+            @Override
+            protected boolean matchesSafely(Request request) {
+                return request.apiKeys() == keys;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("has key " + keys);
+            }
+        }, Action.respond(response, responseApiVersion));
     }
 
     public void addMockResponse(Matcher<Request> matcher, Action action) {

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockServer.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockServer.java
@@ -50,7 +50,7 @@ public final class MockServer implements AutoCloseable {
      */
     public void addMockResponseForApiKey(ResponsePayload response) {
         Objects.requireNonNull(response);
-        serverHandler.setMockResponseForApiKey(response.apiKeys(), response.message());
+        serverHandler.setMockResponseForApiKey(response.apiKeys(), response.message(), response.responseApiVersion());
     }
 
     /**
@@ -60,7 +60,7 @@ public final class MockServer implements AutoCloseable {
     public void addMockResponse(Matcher<Request> requestMatcher, ResponsePayload response) {
         Objects.requireNonNull(response);
         Objects.requireNonNull(requestMatcher);
-        serverHandler.addMockResponse(requestMatcher, Action.respond(response.message()));
+        serverHandler.addMockResponse(requestMatcher, Action.respond(response.message(), response.responseApiVersion()));
     }
 
     public void dropWhen(Matcher<Request> requestMatcher) {

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.proxy.KafkaProxy;
+import io.kroxylicious.proxy.ProxyEnvironment;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.ServiceBasedPluginFactoryRegistry;
@@ -220,7 +221,7 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     public void restartProxy() {
         try {
             proxy.close();
-            proxy = spawnProxy(kroxyliciousConfig);
+            proxy = spawnProxy(kroxyliciousConfig, ProxyEnvironment.DEVELOPMENT);
         }
         catch (Exception e) {
             throw new IllegalStateException(e);
@@ -257,8 +258,8 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
         }
     }
 
-    static KafkaProxy spawnProxy(Configuration config) {
-        KafkaProxy kafkaProxy = new KafkaProxy(new ServiceBasedPluginFactoryRegistry(), config);
+    static KafkaProxy spawnProxy(Configuration config, ProxyEnvironment proxyEnvironment) {
+        KafkaProxy kafkaProxy = new KafkaProxy(new ServiceBasedPluginFactoryRegistry(), config, proxyEnvironment);
         try {
             kafkaProxy.startup();
         }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTesterBuilder.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTesterBuilder.java
@@ -6,8 +6,9 @@
 
 package io.kroxylicious.test.tester;
 
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
+import io.kroxylicious.proxy.ProxyEnvironment;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 
@@ -23,7 +24,8 @@ public class KroxyliciousTesterBuilder {
     private String trustStoreLocation = null;
     @Nullable
     private String trustStorePassword = null;
-    private Function<Configuration, AutoCloseable> kroxyliciousFactory = DefaultKroxyliciousTester::spawnProxy;
+    private BiFunction<ProxyEnvironment, Configuration, AutoCloseable> kroxyliciousFactory = (env, config) -> DefaultKroxyliciousTester.spawnProxy(config, env);
+    private ProxyEnvironment environment = ProxyEnvironment.PRODUCTION;
     private DefaultKroxyliciousTester.ClientFactory clientFactory = (clusterName, defaultConfiguration) -> new KroxyliciousClients(defaultConfiguration);
     private ConfigurationBuilder configurationBuilder;
 
@@ -67,18 +69,19 @@ public class KroxyliciousTesterBuilder {
      */
     public DefaultKroxyliciousTester createDefaultKroxyliciousTester() {
         final TrustStoreConfiguration trustStoreConfiguration = trustStoreLocation != null ? new TrustStoreConfiguration(trustStoreLocation, trustStorePassword) : null;
-        return new DefaultKroxyliciousTester(configurationBuilder, kroxyliciousFactory, clientFactory, trustStoreConfiguration);
+        return new DefaultKroxyliciousTester(configurationBuilder, configuration -> kroxyliciousFactory.apply(environment, configuration), clientFactory,
+                trustStoreConfiguration);
     }
 
     /**
      * Supplies a function which translates Kroxylicious config into a kroxylicious instance.
      * <p>
-     * <em>Intended for internal use to allow unit testing of the testers.</em>
+     * <em>Intended to enable alternative strategies like running the proxy in-process or in a new process.</em>
      *
      * @param kroxyliciousFactory config translation function.
      * @return the current instance of the builder for chaining in a fluent fashion.
      */
-    KroxyliciousTesterBuilder setKroxyliciousFactory(Function<Configuration, AutoCloseable> kroxyliciousFactory) {
+    public KroxyliciousTesterBuilder setKroxyliciousFactory(BiFunction<ProxyEnvironment, Configuration, AutoCloseable> kroxyliciousFactory) {
         this.kroxyliciousFactory = kroxyliciousFactory;
         return this;
     }
@@ -93,6 +96,18 @@ public class KroxyliciousTesterBuilder {
      */
     KroxyliciousTesterBuilder setClientFactory(DefaultKroxyliciousTester.ClientFactory clientFactory) {
         this.clientFactory = clientFactory;
+        return this;
+    }
+
+    /**
+     * Sets the environment of the proxy. By default we run tests with a production environment but
+     * testers can opt in to a DEVELOPMENT environment to allow the proxy to be configured with some
+     * experimental features.
+     * @param environment environment
+     * @return the current instance of the builder for chaining in a fluent fashion.
+     */
+    public KroxyliciousTesterBuilder setEnvironment(ProxyEnvironment environment) {
+        this.environment = environment;
         return this;
     }
 

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTesterBuilder.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTesterBuilder.java
@@ -102,7 +102,7 @@ public class KroxyliciousTesterBuilder {
     /**
      * Sets the environment of the proxy. By default we run tests with a production environment but
      * testers can opt in to a DEVELOPMENT environment to allow the proxy to be configured with some
-     * experimental features.
+     * internal features.
      * @param environment environment
      * @return the current instance of the builder for chaining in a fluent fashion.
      */

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTesters.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTesters.java
@@ -72,7 +72,7 @@ public class KroxyliciousTesters {
      * mock kafka broker. The mock can be configured to respond with an exact API
      * message, and be used to verify what was sent to it.
      * @param configurationForMockBootstrap a function that takes the mock broker's bootstrap server address and returns a KroxyliciousConfigBuilder used to configure an in-process Kroxylicious
-     * @param environment environment of the proxy, set to DEVELOPMENT to allow experimental testing features
+     * @param environment environment of the proxy, set to DEVELOPMENT to allow internal testing features
      * @return KroxyliciousTester
      */
     public static MockServerKroxyliciousTester mockKafkaKroxyliciousTester(Function<String, ConfigurationBuilder> configurationForMockBootstrap,

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTesters.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTesters.java
@@ -6,8 +6,10 @@
 
 package io.kroxylicious.test.tester;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import io.kroxylicious.proxy.ProxyEnvironment;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.test.server.MockServer;
@@ -48,7 +50,8 @@ public class KroxyliciousTesters {
      * @param kroxyliciousFactory factory that takes a KroxyliciousConfig and is responsible for starting a Kroxylicious instance for that config
      * @return KroxyliciousTester
      */
-    public static KroxyliciousTester kroxyliciousTester(ConfigurationBuilder configurationBuilder, Function<Configuration, AutoCloseable> kroxyliciousFactory) {
+    public static KroxyliciousTester kroxyliciousTester(ConfigurationBuilder configurationBuilder,
+                                                        BiFunction<ProxyEnvironment, Configuration, AutoCloseable> kroxyliciousFactory) {
         return new KroxyliciousTesterBuilder().setConfigurationBuilder(configurationBuilder).setKroxyliciousFactory(kroxyliciousFactory)
                 .setClientFactory((clusterName, defaultClientConfiguration) -> new KroxyliciousClients(defaultClientConfiguration)).createDefaultKroxyliciousTester();
     }
@@ -61,7 +64,21 @@ public class KroxyliciousTesters {
      * @return KroxyliciousTester
      */
     public static MockServerKroxyliciousTester mockKafkaKroxyliciousTester(Function<String, ConfigurationBuilder> configurationForMockBootstrap) {
-        return new MockServerKroxyliciousTester(MockServer.startOnRandomPort(), configurationForMockBootstrap, DefaultKroxyliciousTester::spawnProxy,
+        return mockKafkaKroxyliciousTester(configurationForMockBootstrap, ProxyEnvironment.PRODUCTION);
+    }
+
+    /**
+     * Creates a kroxylicious tester for a kroxylicious instance that is proxying a
+     * mock kafka broker. The mock can be configured to respond with an exact API
+     * message, and be used to verify what was sent to it.
+     * @param configurationForMockBootstrap a function that takes the mock broker's bootstrap server address and returns a KroxyliciousConfigBuilder used to configure an in-process Kroxylicious
+     * @param environment environment of the proxy, set to DEVELOPMENT to allow experimental testing features
+     * @return KroxyliciousTester
+     */
+    public static MockServerKroxyliciousTester mockKafkaKroxyliciousTester(Function<String, ConfigurationBuilder> configurationForMockBootstrap,
+                                                                           ProxyEnvironment environment) {
+        return new MockServerKroxyliciousTester(MockServer.startOnRandomPort(), configurationForMockBootstrap,
+                config -> DefaultKroxyliciousTester.spawnProxy(config, environment),
                 (clusterName, defaultClientConfiguration) -> new KroxyliciousClients(defaultClientConfiguration), null);
     }
 

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/MockServerKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/MockServerKroxyliciousTester.java
@@ -139,4 +139,8 @@ public class MockServerKroxyliciousTester extends DefaultKroxyliciousTester {
             }
         };
     }
+
+    public int getReceivedRequestCount() {
+        return mockServer.getReceivedRequests().size();
+    }
 }

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/client/KafkaClientTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/client/KafkaClientTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.client;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.ApiVersionsRequest;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.junit.jupiter.api.Test;
+
+import io.netty.buffer.Unpooled;
+
+import io.kroxylicious.test.Request;
+import io.kroxylicious.test.Response;
+import io.kroxylicious.test.ResponsePayload;
+import io.kroxylicious.test.codec.OpaqueRequestFrame;
+import io.kroxylicious.test.server.MockServer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaClientTest {
+    @Test
+    void testClientCanSendOpaqueFrame() {
+        ApiVersionsResponseData message = new ApiVersionsResponseData();
+        message.setErrorCode(Errors.UNSUPPORTED_VERSION.code());
+        try (var mockServer = MockServer.startOnRandomPort(new ResponsePayload(ApiKeys.API_VERSIONS, (short) 0, message));
+                var kafkaClient = new KafkaClient("127.0.0.1", mockServer.port())) {
+            ApiVersionsRequest request = new ApiVersionsRequest(new ApiVersionsRequestData(), (short) 0);
+            int correlationId = 5;
+            ByteBuffer byteBuffer = request.serializeWithHeader(new RequestHeader(ApiKeys.API_VERSIONS, (short) 0, "client", correlationId));
+            int length = byteBuffer.remaining();
+            OpaqueRequestFrame frame = new OpaqueRequestFrame(Unpooled.copiedBuffer(byteBuffer), correlationId, length, true, ApiKeys.API_VERSIONS, (short) 0);
+            CompletableFuture<Response> future = kafkaClient.get(frame);
+            assertThat(future).succeedsWithin(10, TimeUnit.SECONDS).satisfies(response -> {
+                assertThat(response.payload().message()).isInstanceOfSatisfying(ApiVersionsResponseData.class, apiVersionsRequestData -> {
+                    assertThat(apiVersionsRequestData.errorCode()).isEqualTo(Errors.UNSUPPORTED_VERSION.code());
+                });
+            });
+        }
+    }
+
+    // brokers can respond with a v0 response if they do not support the ApiVersions request version, see KIP-511
+    @Test
+    void testClientCanTolerateV0ApiVersionsResponseToHigherRequestVersion() {
+        ApiVersionsResponseData message = new ApiVersionsResponseData();
+        message.setErrorCode(Errors.UNSUPPORTED_VERSION.code());
+        ResponsePayload v0Payload = new ResponsePayload(ApiKeys.API_VERSIONS, (short) 0, message);
+        try (var mockServer = MockServer.startOnRandomPort(v0Payload);
+                var kafkaClient = new KafkaClient("127.0.0.1", mockServer.port())) {
+            CompletableFuture<Response> future = kafkaClient.get(new Request(ApiKeys.API_VERSIONS, (short) 0, "client", new ApiVersionsRequestData()));
+            assertThat(future).succeedsWithin(10, TimeUnit.SECONDS).satisfies(response -> {
+                assertThat(response.payload().message()).isInstanceOfSatisfying(ApiVersionsResponseData.class, apiVersionsRequestData -> {
+                    assertThat(apiVersionsRequestData.errorCode()).isEqualTo(Errors.UNSUPPORTED_VERSION.code());
+                });
+            });
+        }
+    }
+}

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/DefaultKroxyliciousTesterTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/DefaultKroxyliciousTesterTest.java
@@ -507,7 +507,7 @@ class DefaultKroxyliciousTesterTest {
                 .endAdminHttp();
         var testerBuilder = new KroxyliciousTesterBuilder()
                 .setConfigurationBuilder(proxy)
-                .setKroxyliciousFactory(DefaultKroxyliciousTester::spawnProxy);
+                .setKroxyliciousFactory((env, config) -> DefaultKroxyliciousTester.spawnProxy(config, env));
 
         try (var tester = (KroxyliciousTester) testerBuilder
                 .createDefaultKroxyliciousTester()) {
@@ -537,7 +537,7 @@ class DefaultKroxyliciousTesterTest {
     @NonNull
     private KroxyliciousTester buildDefaultTester() {
         return new KroxyliciousTesterBuilder().setConfigurationBuilder(proxy(backingCluster))
-                .setKroxyliciousFactory(DefaultKroxyliciousTester::spawnProxy)
+                .setKroxyliciousFactory((env, config) -> DefaultKroxyliciousTester.spawnProxy(config, env))
                 .setClientFactory(clientFactory)
                 .createDefaultKroxyliciousTester();
     }
@@ -565,7 +565,8 @@ class DefaultKroxyliciousTesterTest {
         return new KroxyliciousTesterBuilder().setConfigurationBuilder(configurationBuilder)
                 .setTrustStoreLocation(keytoolCertificateGenerator.getTrustStoreLocation())
                 .setTrustStorePassword(keytoolCertificateGenerator.getPassword())
-                .setKroxyliciousFactory(DefaultKroxyliciousTester::spawnProxy).setClientFactory(clientFactory).createDefaultKroxyliciousTester();
+                .setKroxyliciousFactory((env, config) -> DefaultKroxyliciousTester.spawnProxy(config, env)).setClientFactory(clientFactory)
+                .createDefaultKroxyliciousTester();
     }
 
     private static void generateSecurityCert(KeytoolCertificateGenerator keytoolCertificateGenerator) {
@@ -580,7 +581,8 @@ class DefaultKroxyliciousTesterTest {
     private KroxyliciousTester buildTester() {
         return new KroxyliciousTesterBuilder()
                 .setConfigurationBuilder(proxy(backingCluster, VIRTUAL_CLUSTER_A, VIRTUAL_CLUSTER_B, VIRTUAL_CLUSTER_C))
-                .setKroxyliciousFactory(DefaultKroxyliciousTester::spawnProxy).setClientFactory(clientFactory).createDefaultKroxyliciousTester();
+                .setKroxyliciousFactory((env, config) -> DefaultKroxyliciousTester.spawnProxy(config, env)).setClientFactory(clientFactory)
+                .createDefaultKroxyliciousTester();
     }
 
     public static <T> T argThat(Consumer<T> assertions) {

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
@@ -257,6 +257,13 @@ class KroxyliciousTestersTest {
     }
 
     @Test
+    void testMockRequestInitialRequestCount() {
+        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy)) {
+            assertThat(tester.getReceivedRequestCount()).isZero();
+        }
+    }
+
+    @Test
     void testSimpleTestClientReportsConnectionState() {
         try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
                 var kafkaClient = tester.simpleTestClient()) {
@@ -334,6 +341,7 @@ class KroxyliciousTestersTest {
             assertThat(response1Message).isEqualTo(mockResponse1);
             assertThat(tester.getOnlyRequestForApiKey(ApiKeys.DESCRIBE_ACLS)).isEqualTo(describeAcls);
             assertThat(tester.getRequestsForApiKey(ApiKeys.DESCRIBE_ACLS)).containsOnly(describeAcls);
+            assertThat(tester.getReceivedRequestCount()).isEqualTo(1);
 
             Request listTransactions = new Request(ApiKeys.LIST_TRANSACTIONS, ApiKeys.LIST_TRANSACTIONS.latestVersion(), "client", new ListTransactionsRequestData());
             var response2 = kafkaClient.getSync(listTransactions);
@@ -343,6 +351,7 @@ class KroxyliciousTestersTest {
             assertThat(response2Message).isEqualTo(mockResponse2);
             assertThat(tester.getOnlyRequestForApiKey(ApiKeys.LIST_TRANSACTIONS)).isEqualTo(listTransactions);
             assertThat(tester.getRequestsForApiKey(ApiKeys.LIST_TRANSACTIONS)).containsOnly(listTransactions);
+            assertThat(tester.getReceivedRequestCount()).isEqualTo(2);
         }
     }
 

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -142,6 +142,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <scope>test</scope>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsDowngradeIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsDowngradeIT.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.NodeApiVersions;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.security.plain.PlainLoginModule;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import io.kroxylicious.test.Response;
+import io.kroxylicious.test.codec.ByteBufAccessorImpl;
+import io.kroxylicious.test.codec.OpaqueRequestFrame;
+import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.SaslMechanism;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * <p>
+ * In addition to the behaviour tested by {@link ApiVersionsIT} we also need to handle the client
+ * sending ApiVersions requests at an apiVersion higher than the proxy understands. With no proxy
+ * involved, the behaviour is the broker will respond with a v0 apiversions response and the error
+ * code is set to UNSUPPORTED_VERSION and the api_versions array populated with the supported versions
+ * for ApiVersions, so that the client can retry with the highest supported ApiVersions version.
+ * </p>
+ * <br>
+ * In this case the proxy will respond with it's own v0 response populated with the proxies supported
+ * ApiVersions versions. It may be that on the following request the upstream broker will be behind
+ * the proxy and respond with it's own UNSUPPORTED_VERSION response. So the clients must be able to
+ * tolerate 2 UNSUPPORTED_VERSION responses in a row.
+ * </p>
+ */
+@ExtendWith(NettyLeakDetectorExtension.class)
+@ExtendWith(KafkaClusterExtension.class)
+public class ApiVersionsDowngradeIT {
+
+    public static final int CORRELATION_ID = 100;
+    public static final short API_VERSIONS_ID = ApiKeys.API_VERSIONS.id;
+    public static final String SASL_USER = "alice";
+    public static final String SASL_PASSWORD = "foo";
+
+    @Test
+    void clientAheadOfProxy() {
+        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+                var client = tester.simpleTestClient()) {
+            OpaqueRequestFrame frame = createHypotheticalFutureRequest();
+            CompletableFuture<Response> responseCompletableFuture = client.get(
+                    frame);
+            assertThat(responseCompletableFuture).succeedsWithin(5, TimeUnit.SECONDS).satisfies(response -> {
+                assertThat(response.payload().apiKeys()).isEqualTo(ApiKeys.API_VERSIONS);
+                assertThat(response.payload().message()).isInstanceOfSatisfying(ApiVersionsResponseData.class, data -> {
+                    assertThat(data.errorCode()).isEqualTo(Errors.UNSUPPORTED_VERSION.code());
+                    ApiVersionsResponseData.ApiVersion expected = new ApiVersionsResponseData.ApiVersion();
+                    expected.setApiKey(ApiKeys.API_VERSIONS.id).setMinVersion(ApiKeys.API_VERSIONS.oldestVersion())
+                            .setMaxVersion(ApiKeys.API_VERSIONS.latestVersion(true));
+                    ApiVersionsResponseData.ApiVersionCollection collection = new ApiVersionsResponseData.ApiVersionCollection();
+                    collection.add(expected);
+                    assertThat(data.apiKeys()).isEqualTo(collection);
+                });
+            });
+            assertThat(tester.getReceivedRequestCount()).isZero();
+        }
+    }
+
+    @Test
+    void proxyRestrictedToOlderApiVersion(KafkaCluster cluster) {
+        doProxyRestrictedToOlderApiVersion(cluster, Map.of());
+    }
+
+    @Test
+    void proxyRestrictedToOlderApiVersionWithSasl(@SaslMechanism(principals = {
+            @SaslMechanism.Principal(user = SASL_USER, password = SASL_PASSWORD) }) KafkaCluster cluster) {
+        var clientSecurityProtocolConfig = new HashMap<String, Object>();
+        clientSecurityProtocolConfig.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_PLAINTEXT.name);
+        clientSecurityProtocolConfig.put(SaslConfigs.SASL_JAAS_CONFIG,
+                String.format("""
+                        %s required username="%s" password="%s";""",
+                        PlainLoginModule.class.getName(), SASL_USER, SASL_PASSWORD));
+        clientSecurityProtocolConfig.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+
+        doProxyRestrictedToOlderApiVersion(cluster, clientSecurityProtocolConfig);
+    }
+
+    private void doProxyRestrictedToOlderApiVersion(KafkaCluster cluster, Map<String, Object> clientSecurityProtocolConfig) {
+        var apiVersion = (short) (ApiKeys.API_VERSIONS.latestVersion() - 1);
+        var proxy = proxy(cluster)
+                .withExperimental(Map.of("apiKeyIdMaxVersionOverride", Map.of(ApiKeys.API_VERSIONS.name(), apiVersion)));
+        try (var tester = kroxyliciousTester(proxy);
+                var admin = tester.admin(clientSecurityProtocolConfig)) {
+            // We've got no way to observe the actual version of the API versions request that is used during _negotiation_
+            // so we make do with asserting the connection is usable.
+            final var result = admin.describeCluster().clusterId();
+            assertThat(result).as("Unable to get the clusterId from the Kafka cluster").succeedsWithin(Duration.ofSeconds(10));
+            // check that the client is actually using the correct version.
+            assertThat(admin)
+                    .extracting("instance")
+                    .extracting("client")
+                    .extracting("apiVersions")
+                    .extracting("nodeApiVersions", InstanceOfAssertFactories.map(String.class, NodeApiVersions.class))
+                    .hasEntrySatisfying("0", nav -> {
+                        assertThat(nav.apiVersion(ApiKeys.API_VERSIONS).maxVersion())
+                                .isEqualTo(apiVersion);
+                    });
+        }
+    }
+
+    private static @NonNull OpaqueRequestFrame createHypotheticalFutureRequest() {
+        short unsupportedVersion = (short) (ApiKeys.API_VERSIONS.latestVersion(true) + 1);
+        RequestHeaderData requestHeaderData = getRequestHeaderData(API_VERSIONS_ID, unsupportedVersion, CORRELATION_ID);
+        short requestHeaderVersion = ApiKeys.API_VERSIONS.requestHeaderVersion(unsupportedVersion);
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        int headerSize = requestHeaderData.size(cache, requestHeaderVersion);
+        // the proxy can assume that it is safe to read the latest header version from the message, but any
+        // bytes after than cannot be read because the future message may be using a new header version with
+        // additional fields. So the bytes after the latest known header bytes are arbitrary as far as the proxy
+        // is concerned.
+        byte[] arbitraryBodyData = new byte[]{ 1, 2, 3, 4 };
+        int bodySize = arbitraryBodyData.length;
+        int messageSize = headerSize + bodySize;
+        ByteBuf buffer = Unpooled.buffer(messageSize, messageSize);
+        ByteBufAccessorImpl accessor = new ByteBufAccessorImpl(buffer);
+        requestHeaderData.write(accessor, cache, requestHeaderVersion);
+        accessor.writeByteArray(arbitraryBodyData);
+        return new OpaqueRequestFrame(buffer, CORRELATION_ID, messageSize, true, ApiKeys.API_VERSIONS, unsupportedVersion);
+    }
+
+    private static @NonNull RequestHeaderData getRequestHeaderData(short apiKey, short unsupportedVersion, int correlationId) {
+        RequestHeaderData requestHeaderData = new RequestHeaderData();
+        requestHeaderData.setRequestApiKey(apiKey);
+        requestHeaderData.setRequestApiVersion(unsupportedVersion);
+        requestHeaderData.setCorrelationId(correlationId);
+        return requestHeaderData;
+    }
+
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsDowngradeIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsDowngradeIT.java
@@ -23,7 +23,12 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.utility.DockerImageName;
 
 import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 import io.netty.buffer.ByteBuf;
@@ -68,6 +73,7 @@ public class ApiVersionsDowngradeIT {
     public static final short API_VERSIONS_ID = ApiKeys.API_VERSIONS.id;
     public static final String SASL_USER = "alice";
     public static final String SASL_PASSWORD = "foo";
+    private static final DockerImageName OLD_REDPANDA_USING_API_VER0_2 = DockerImageName.parse("docker.redpanda.com/redpandadata/redpanda:v22.1.11");
 
     @Test
     void clientAheadOfProxy() {
@@ -134,6 +140,50 @@ public class ApiVersionsDowngradeIT {
         }
     }
 
+    /**
+     * In this test, we verify the assumption that the Kafka Client is capable
+     * of negotiating down api-versions version twice.  This test uses an
+     * old version of Redpanda (that supports max v2) and the Proxy (restricted
+     * to v3).  The Kafka Client is using v4.
+     * <br>
+     * Client will first make a v4 request.  The proxy's response will cause the client
+     * to try again at v3.  The broker will then cause the client to try a third time at v2.
+     * This request will satisfy all parties and the connection establishment will continue.
+     * All this occurs on a single connection.
+     */
+    @Test
+    @EnabledIf(value = "isDockerAvailable", disabledReason = "docker unavailable")
+    void clientAheadOfProxyWhichIsAheadOfBroker() {
+
+        try (var redpanda = createRedpanda(OLD_REDPANDA_USING_API_VER0_2)) {
+            redpanda.start();
+            var redpandaApiVersion = (short) 2;
+            var proxyApiVersion = (short) (ApiKeys.API_VERSIONS.latestVersion() - 1);
+            assertThat(redpandaApiVersion).isLessThan(proxyApiVersion);
+
+            var proxy = proxy("localhost:9092")
+                    .withInternal(Map.of("apiKeyIdMaxVersionOverride", Map.of(ApiKeys.API_VERSIONS.name(), proxyApiVersion)));
+            try (var tester = newBuilder(proxy).setEnvironment(DEVELOPMENT).createDefaultKroxyliciousTester();
+                    var admin = tester.admin()) {
+                // We've got no way to observe the actual version of the API versions request that is used during _negotiation_
+                // so we make do with asserting the connection is usable.
+                final var result = admin.describeCluster().clusterId();
+                assertThat(result).as("Unable to get the clusterId from the Kafka cluster").succeedsWithin(Duration.ofSeconds(10));
+                // check that the client is actually using the correct version.
+                assertThat(admin)
+                        .extracting("instance")
+                        .extracting("client")
+                        .extracting("apiVersions")
+                        .extracting("nodeApiVersions", InstanceOfAssertFactories.map(String.class, NodeApiVersions.class))
+                        .hasEntrySatisfying("-1", nav -> {
+                            assertThat(nav.apiVersion(ApiKeys.API_VERSIONS).maxVersion())
+                                    .isEqualTo(redpandaApiVersion);
+                        });
+            }
+
+        }
+    }
+
     private static @NonNull OpaqueRequestFrame createHypotheticalFutureRequest() {
         short unsupportedVersion = (short) (ApiKeys.API_VERSIONS.latestVersion(true) + 1);
         RequestHeaderData requestHeaderData = getRequestHeaderData(API_VERSIONS_ID, unsupportedVersion, CORRELATION_ID);
@@ -162,4 +212,27 @@ public class ApiVersionsDowngradeIT {
         return requestHeaderData;
     }
 
+    @NonNull
+    private RedpandaContainer createRedpanda(DockerImageName image) {
+        var redpanda = new RedpandaContainer(image);
+        redpanda.setWaitStrategy(new LogMessageWaitStrategy().withRegEx(".*Bootstrap complete.*"));
+        redpanda.addFixedExposedPort(9092, 9092);
+        return redpanda;
+    }
+
+    private static class RedpandaContainer extends GenericContainer<RedpandaContainer> {
+
+        private RedpandaContainer(DockerImageName dockerImageName) {
+            super(dockerImageName);
+        }
+
+        @Override
+        protected void addFixedExposedPort(int hostPort, int containerPort) {
+            super.addFixedExposedPort(hostPort, containerPort);
+        }
+    }
+
+    static boolean isDockerAvailable() {
+        return DockerClientFactory.instance().isDockerAvailable();
+    }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsDowngradeIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsDowngradeIT.java
@@ -39,9 +39,10 @@ import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import static io.kroxylicious.proxy.ProxyEnvironment.DEVELOPMENT;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
-import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.newBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -114,7 +115,7 @@ public class ApiVersionsDowngradeIT {
         var apiVersion = (short) (ApiKeys.API_VERSIONS.latestVersion() - 1);
         var proxy = proxy(cluster)
                 .withExperimental(Map.of("apiKeyIdMaxVersionOverride", Map.of(ApiKeys.API_VERSIONS.name(), apiVersion)));
-        try (var tester = kroxyliciousTester(proxy);
+        try (var tester = newBuilder(proxy).setEnvironment(DEVELOPMENT).createDefaultKroxyliciousTester();
                 var admin = tester.admin(clientSecurityProtocolConfig)) {
             // We've got no way to observe the actual version of the API versions request that is used during _negotiation_
             // so we make do with asserting the connection is usable.

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsDowngradeIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsDowngradeIT.java
@@ -114,7 +114,7 @@ public class ApiVersionsDowngradeIT {
     private void doProxyRestrictedToOlderApiVersion(KafkaCluster cluster, Map<String, Object> clientSecurityProtocolConfig) {
         var apiVersion = (short) (ApiKeys.API_VERSIONS.latestVersion() - 1);
         var proxy = proxy(cluster)
-                .withExperimental(Map.of("apiKeyIdMaxVersionOverride", Map.of(ApiKeys.API_VERSIONS.name(), apiVersion)));
+                .withInternal(Map.of("apiKeyIdMaxVersionOverride", Map.of(ApiKeys.API_VERSIONS.name(), apiVersion)));
         try (var tester = newBuilder(proxy).setEnvironment(DEVELOPMENT).createDefaultKroxyliciousTester();
                 var admin = tester.admin(clientSecurityProtocolConfig)) {
             // We've got no way to observe the actual version of the API versions request that is used during _negotiation_

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsIT.java
@@ -55,7 +55,7 @@ public class ApiVersionsIT {
     void shouldOfferTheMinimumHighestSupportedVersionWhenBrokerIsAheadOfKroxyliciousAndMaxVersionOverridden() {
         short overriddenVersion = (short) (ApiKeys.METADATA.latestVersion(true) - 1);
         try (var tester = mockKafkaKroxyliciousTester((bootstrap) -> KroxyliciousConfigUtils.proxy(bootstrap)
-                .withExperimental(Map.of("apiKeyIdMaxVersionOverride", Map.of(ApiKeys.METADATA.name(), overriddenVersion))), DEVELOPMENT);
+                .withInternal(Map.of("apiKeyIdMaxVersionOverride", Map.of(ApiKeys.METADATA.name(), overriddenVersion))), DEVELOPMENT);
                 var client = tester.simpleTestClient()) {
             givenMockRespondsWithApiVersionsForApiKey(tester, ApiKeys.METADATA, ApiKeys.METADATA.oldestVersion(), ApiKeys.METADATA.latestVersion(true));
             Response response = whenGetApiVersionsFromKroxylicious(client);

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsIT.java
@@ -23,6 +23,7 @@ import io.kroxylicious.test.client.KafkaClient;
 import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
 import io.kroxylicious.test.tester.MockServerKroxyliciousTester;
 
+import static io.kroxylicious.proxy.ProxyEnvironment.DEVELOPMENT;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -54,7 +55,7 @@ public class ApiVersionsIT {
     void shouldOfferTheMinimumHighestSupportedVersionWhenBrokerIsAheadOfKroxyliciousAndMaxVersionOverridden() {
         short overriddenVersion = (short) (ApiKeys.METADATA.latestVersion(true) - 1);
         try (var tester = mockKafkaKroxyliciousTester((bootstrap) -> KroxyliciousConfigUtils.proxy(bootstrap)
-                .withExperimental(Map.of("apiKeyIdMaxVersionOverride", Map.of(ApiKeys.METADATA.name(), overriddenVersion))));
+                .withExperimental(Map.of("apiKeyIdMaxVersionOverride", Map.of(ApiKeys.METADATA.name(), overriddenVersion))), DEVELOPMENT);
                 var client = tester.simpleTestClient()) {
             givenMockRespondsWithApiVersionsForApiKey(tester, ApiKeys.METADATA, ApiKeys.METADATA.oldestVersion(), ApiKeys.METADATA.latestVersion(true));
             Response response = whenGetApiVersionsFromKroxylicious(client);

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
@@ -129,7 +129,7 @@ public class ProxyConfigSecret
                 virtualClusters,
                 filterDefinitions,
                 List.of(),
-                false);
+                false, null);
 
         return toYaml(configuration);
     }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
@@ -129,7 +129,7 @@ public class ProxyConfigSecret
                 virtualClusters,
                 filterDefinitions,
                 List.of(),
-                false, null);
+                false, Optional.empty());
 
         return toYaml(configuration);
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/EnvironmentConfigurationException.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/EnvironmentConfigurationException.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy;
+
+public class EnvironmentConfigurationException extends RuntimeException {
+    public EnvironmentConfigurationException(String message) {
+        super(message);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -12,7 +12,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +41,7 @@ import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.MicrometerDefinition;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
+import io.kroxylicious.proxy.internal.ApiVersionsServiceImpl;
 import io.kroxylicious.proxy.internal.KafkaProxyInitializer;
 import io.kroxylicious.proxy.internal.MeterRegistries;
 import io.kroxylicious.proxy.internal.PortConflictDetector;
@@ -111,11 +114,13 @@ public final class KafkaProxy implements AutoCloseable {
 
             maybeStartMetricsListener(adminEventGroup, meterRegistries);
 
+            var overrideMap = getApiKeyMaxVersionOverride(config);
+            ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl(overrideMap);
             this.filterChainFactory = new FilterChainFactory(pfr, config.filters());
             var tlsServerBootstrap = buildServerBootstrap(serverEventGroup,
-                    new KafkaProxyInitializer(filterChainFactory, pfr, true, endpointRegistry, endpointRegistry, false, Map.of()));
+                    new KafkaProxyInitializer(filterChainFactory, pfr, true, endpointRegistry, endpointRegistry, false, Map.of(), apiVersionsService));
             var plainServerBootstrap = buildServerBootstrap(serverEventGroup,
-                    new KafkaProxyInitializer(filterChainFactory, pfr, false, endpointRegistry, endpointRegistry, false, Map.of()));
+                    new KafkaProxyInitializer(filterChainFactory, pfr, false, endpointRegistry, endpointRegistry, false, Map.of(), apiVersionsService));
 
             bindingOperationProcessor.start(plainServerBootstrap, tlsServerBootstrap);
 
@@ -134,6 +139,19 @@ public final class KafkaProxy implements AutoCloseable {
             shutdown();
             throw e;
         }
+    }
+
+    private Map<ApiKeys, Short> getApiKeyMaxVersionOverride(Configuration config) {
+        Map<String, Number> apiKeyIdMaxVersion = config.experimental()
+                .map(m -> m.get("apiKeyIdMaxVersionOverride"))
+                .filter(Map.class::isInstance)
+                .map(Map.class::cast)
+                .orElse(Map.of());
+
+        return apiKeyIdMaxVersion.entrySet()
+                .stream()
+                .collect(Collectors.toMap(e -> ApiKeys.valueOf(e.getKey()),
+                        e -> e.getValue().shortValue()));
     }
 
     private ServerBootstrap buildServerBootstrap(EventGroupConfig virtualHostEventGroup, KafkaProxyInitializer kafkaProxyInitializer) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -83,9 +83,9 @@ public final class KafkaProxy implements AutoCloseable {
     private @Nullable EventGroupConfig serverEventGroup;
     private @Nullable Channel metricsChannel;
 
-    public KafkaProxy(PluginFactoryRegistry pfr, Configuration config) {
+    public KafkaProxy(PluginFactoryRegistry pfr, Configuration config, ProxyEnvironment environment) {
         this.pfr = Objects.requireNonNull(pfr);
-        this.config = Objects.requireNonNull(config);
+        this.config = environment.validate(config);
         this.virtualClusters = config.virtualClusterModel();
         this.adminHttpConfig = config.adminHttpConfig();
         this.micrometerConfig = config.getMicrometer();

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -142,7 +142,7 @@ public final class KafkaProxy implements AutoCloseable {
     }
 
     private Map<ApiKeys, Short> getApiKeyMaxVersionOverride(Configuration config) {
-        Map<String, Number> apiKeyIdMaxVersion = config.experimental()
+        Map<String, Number> apiKeyIdMaxVersion = config.internal()
                 .map(m -> m.get("apiKeyIdMaxVersionOverride"))
                 .filter(Map.class::isInstance)
                 .map(Map.class::cast)

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/ProxyEnvironment.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/ProxyEnvironment.java
@@ -14,8 +14,8 @@ public enum ProxyEnvironment {
     PRODUCTION {
         @Override
         public Configuration validate(@NonNull Configuration config) {
-            if (config.internal() != null && config.internal().isPresent()) {
-                throw new EnvironmentConfigurationException("internal configuration for proxy present in production mode");
+            if (config.internal().map(m -> !m.isEmpty()).orElse(false)) {
+                throw new EnvironmentConfigurationException("internal configuration for proxy present in production environment");
             }
             return config;
         }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/ProxyEnvironment.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/ProxyEnvironment.java
@@ -14,8 +14,8 @@ public enum ProxyEnvironment {
     PRODUCTION {
         @Override
         public Configuration validate(@NonNull Configuration config) {
-            if (config.experimental() != null && config.experimental().isPresent()) {
-                throw new EnvironmentConfigurationException("experimental configuration for proxy present in production mode");
+            if (config.internal() != null && config.internal().isPresent()) {
+                throw new EnvironmentConfigurationException("internal configuration for proxy present in production mode");
             }
             return config;
         }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/ProxyEnvironment.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/ProxyEnvironment.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy;
+
+import io.kroxylicious.proxy.config.Configuration;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public enum ProxyEnvironment {
+    PRODUCTION {
+        @Override
+        public Configuration validate(@NonNull Configuration config) {
+            if (config.experimental() != null && config.experimental().isPresent()) {
+                throw new EnvironmentConfigurationException("experimental configuration for proxy present in production mode");
+            }
+            return config;
+        }
+    },
+    DEVELOPMENT;
+
+    /**
+     *
+     * @param config configuration to validate
+     * @return the config object passed in if valid
+     * @throws EnvironmentConfigurationException if config invalid for environment
+     */
+    public Configuration validate(Configuration config) {
+        return config;
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -7,6 +7,7 @@ package io.kroxylicious.proxy.config;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
 
@@ -17,7 +18,8 @@ public record Configuration(@Nullable AdminHttpConfiguration adminHttp,
                             Map<String, VirtualCluster> virtualClusters,
                             List<FilterDefinition> filters,
                             List<MicrometerDefinition> micrometer,
-                            boolean useIoUring) {
+                            boolean useIoUring,
+                            @Nullable Optional<Map<String, Object>> experimental) {
     public @Nullable AdminHttpConfiguration adminHttpConfig() {
         return adminHttp();
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -19,7 +19,7 @@ public record Configuration(@Nullable AdminHttpConfiguration adminHttp,
                             List<FilterDefinition> filters,
                             List<MicrometerDefinition> micrometer,
                             boolean useIoUring,
-                            @Nullable Optional<Map<String, Object>> internal) {
+                            @NonNull Optional<Map<String, Object>> internal) {
     public @Nullable AdminHttpConfiguration adminHttpConfig() {
         return adminHttp();
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -19,7 +19,7 @@ public record Configuration(@Nullable AdminHttpConfiguration adminHttp,
                             List<FilterDefinition> filters,
                             List<MicrometerDefinition> micrometer,
                             boolean useIoUring,
-                            @Nullable Optional<Map<String, Object>> experimental) {
+                            @Nullable Optional<Map<String, Object>> internal) {
     public @Nullable AdminHttpConfiguration adminHttpConfig() {
         return adminHttp();
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ApiVersionsServiceImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ApiVersionsServiceImpl.java
@@ -7,7 +7,15 @@
 package io.kroxylicious.proxy.internal;
 
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersion;
@@ -15,21 +23,59 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 public class ApiVersionsServiceImpl {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApiVersionsServiceImpl.class);
+    private final Function<ApiKeys, Short> apiKeysShortFunction;
 
-    public void updateVersions(String channel, ApiVersionsResponseData apiVersionsResponse) {
-        intersectApiVersions(channel, apiVersionsResponse);
+    public ApiVersionsServiceImpl() {
+        this(Map.of());
     }
 
-    private static void intersectApiVersions(String channel, ApiVersionsResponseData resp) {
+    public ApiVersionsServiceImpl(Map<ApiKeys, Short> overrideMap) {
+        this(apiKeys -> getMaxApiVersionFor(apiKeys, overrideMap));
+        sanityCheckOverrides(overrideMap);
+    }
+
+    private void sanityCheckOverrides(Map<ApiKeys, Short> overrideMap) {
+        List<String> invalidEntries = overrideMap.entrySet().stream().flatMap(e -> validate(e.getKey(), e.getValue())).toList();
+        if (!invalidEntries.isEmpty()) {
+            Collector<CharSequence, ?, String> validationMessages = Collectors.joining(",", "[", "]");
+            throw new IllegalArgumentException("api versions override map contained invalid entries: " + invalidEntries.stream().collect(validationMessages));
+        }
+    }
+
+    private Stream<String> validate(ApiKeys key, Short overrideLatestVersion) {
+        short oldestVersion = key.oldestVersion();
+        if (overrideLatestVersion < oldestVersion) {
+            return Stream.of(key.name() + " specified max version " + overrideLatestVersion + " less than oldest supported version " + key.oldestVersion());
+        }
+        return Stream.of();
+    }
+
+    private ApiVersionsServiceImpl(@NonNull Function<ApiKeys, Short> apiKeysShortFunction) {
+        Objects.requireNonNull(apiKeysShortFunction);
+        this.apiKeysShortFunction = apiKeysShortFunction;
+    }
+
+    private static short getMaxApiVersionFor(ApiKeys apiKey, Map<ApiKeys, Short> overrideMap) {
+        short latest = apiKey.latestVersion(true);
+        return Optional.ofNullable(overrideMap.get(apiKey)).map(m -> ((Integer) Math.min(latest, m.intValue())).shortValue()).orElse(latest);
+    }
+
+    public void updateVersions(String channel, ApiVersionsResponseData apiVersionsResponse) {
+        intersectApiVersions(channel, apiVersionsResponse, apiKeysShortFunction);
+    }
+
+    private static void intersectApiVersions(String channel, ApiVersionsResponseData resp, Function<ApiKeys, Short> apiKeysShortFunction) {
         Set<ApiVersion> unknownApis = new HashSet<>();
         for (var key : resp.apiKeys()) {
             short apiId = key.apiKey();
             if (ApiKeys.hasId(apiId)) {
                 ApiKeys apiKey = ApiKeys.forId(apiId);
-                intersectApiVersion(channel, key, apiKey);
+                intersectApiVersion(channel, key, apiKey, apiKeysShortFunction);
             }
             else {
                 unknownApis.add(key);
@@ -41,11 +87,13 @@ public class ApiVersionsServiceImpl {
     /**
      * Update the given {@code key}'s max and min versions so that the client uses APIs versions mutually
      * understood by both the proxy and the broker.
+     *
      * @param channel The channel.
      * @param key The key data from an upstream API_VERSIONS response.
      * @param apiKey The proxy's API key for this API.
+     * @param apiKeysShortFunction
      */
-    private static void intersectApiVersion(String channel, ApiVersionsResponseData.ApiVersion key, ApiKeys apiKey) {
+    private static void intersectApiVersion(String channel, ApiVersion key, ApiKeys apiKey, Function<ApiKeys, Short> apiKeysShortFunction) {
         short mutualMin = (short) Math.max(
                 key.minVersion(),
                 apiKey.messageType.lowestSupportedVersion());
@@ -59,7 +107,7 @@ public class ApiVersionsServiceImpl {
 
         short mutualMax = (short) Math.min(
                 key.maxVersion(),
-                apiKey.messageType.highestSupportedVersion(true));
+                apiKeysShortFunction.apply(apiKey));
         if (mutualMax != key.maxVersion()) {
             LOGGER.trace("{}: {} max version changed to {} (was: {})", channel, apiKey, mutualMin, key.maxVersion());
             key.setMaxVersion(mutualMax);
@@ -69,4 +117,7 @@ public class ApiVersionsServiceImpl {
         }
     }
 
+    public short latestVersion(ApiKeys apiKey) {
+        return apiKeysShortFunction.apply(apiKey);
+    }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsDowngradeFilter.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsDowngradeFilter.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.protocol.Writable;
+
+import io.kroxylicious.proxy.filter.ApiVersionsRequestFilter;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.internal.ApiVersionsServiceImpl;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class ApiVersionsDowngradeFilter implements ApiVersionsRequestFilter {
+
+    private final ApiVersionsServiceImpl apiVersionsService;
+
+    public ApiVersionsDowngradeFilter(@NonNull ApiVersionsServiceImpl apiVersionsService) {
+        this.apiVersionsService = Objects.requireNonNull(apiVersionsService);
+    }
+
+    /**
+     * This subclass is used when we receive an ApiVersions request at an api version higher
+     * than the proxy supports. It should be handled internally with a short-circuit response
+     * and not forwarded to any broker. Only the ApiVersionsDowngradeFilter should be exposed to
+     * this type.
+     */
+    private static class DowngradeApiVersionsRequestData extends ApiVersionsRequestData {
+
+        private DowngradeApiVersionsRequestData() {
+            super();
+        }
+
+        @Override
+        public void write(Writable writable, ObjectSerializationCache cache, short version) {
+            throw new UnsupportedOperationException("DowngradeApiVersionsRequestData is read-only");
+        }
+
+        @Override
+        public int size(ObjectSerializationCache cache, short version) {
+            throw new UnsupportedOperationException("DowngradeApiVersionsRequestData is read-only");
+        }
+    }
+
+    /**
+     * This subclass is used when we receive an ApiVersions request at an api version higher
+     * than the proxy supports. It should be handled internally with a short-circuit response
+     * and not forwarded further to any broker. Only the ApiVersionsDowngradeFilter should be exposed to
+     * this type.
+     */
+    private static class DowngradeRequestHeaderData extends RequestHeaderData {
+
+        private DowngradeRequestHeaderData() {
+            super();
+        }
+
+        @Override
+        public void write(Writable writable, ObjectSerializationCache cache, short version) {
+            throw new UnsupportedOperationException("DowngradeRequestHeaderData is read-only");
+        }
+
+        @Override
+        public int size(ObjectSerializationCache cache, short version) {
+            throw new UnsupportedOperationException("DowngradeRequestHeaderData is read-only");
+        }
+    }
+
+    private static RequestHeaderData apiVersionsRequestDowngradeHeader(int correlationId) {
+        return new DowngradeRequestHeaderData()
+                .setCorrelationId(correlationId)
+                .setRequestApiKey(ApiKeys.API_VERSIONS.id)
+                .setRequestApiVersion((short) 0);
+    }
+
+    public static DecodedRequestFrame<ApiVersionsRequestData> downgradeApiVersionsFrame(int correlationId) {
+        RequestHeaderData requestHeaderData = apiVersionsRequestDowngradeHeader(correlationId);
+        return new DecodedRequestFrame<>(
+                requestHeaderData.requestApiVersion(), correlationId, true, requestHeaderData, new DowngradeApiVersionsRequestData());
+    }
+
+    @Override
+    public CompletionStage<RequestFilterResult> onApiVersionsRequest(short apiVersion, RequestHeaderData header, ApiVersionsRequestData request, FilterContext context) {
+        if (request instanceof DowngradeApiVersionsRequestData) {
+            ApiVersionsResponseData.ApiVersionCollection collection = new ApiVersionsResponseData.ApiVersionCollection();
+            ApiKeys apiVersions = ApiKeys.API_VERSIONS;
+            ApiVersionsResponseData.ApiVersion version = new ApiVersionsResponseData.ApiVersion()
+                    .setApiKey(apiVersions.id)
+                    .setMinVersion(apiVersions.oldestVersion())
+                    .setMaxVersion(apiVersionsService.latestVersion(apiVersions));
+            collection.add(version);
+            ApiVersionsResponseData message = new ApiVersionsResponseData()
+                    .setApiKeys(collection)
+                    .setErrorCode(Errors.UNSUPPORTED_VERSION.code());
+            return context.requestFilterResultBuilder().shortCircuitResponse(message).completed();
+        }
+        return context.forwardRequest(header, request);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -40,7 +40,7 @@ class KafkaProxyTest {
                    - type: RequiresConfigFactory
                 """;
         var configParser = new ConfigParser();
-        try (var kafkaProxy = new KafkaProxy(configParser, configParser.parseConfiguration(config))) {
+        try (var kafkaProxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), ProxyEnvironment.DEVELOPMENT)) {
             assertThatThrownBy(kafkaProxy::startup).isInstanceOf(PluginConfigurationException.class)
                     .hasMessage(
                             "Exception initializing filter factory RequiresConfigFactory with config null: RequiresConfigFactory requires configuration, but config object is null");
@@ -94,7 +94,7 @@ class KafkaProxyTest {
     @MethodSource
     void detectsConflictingPorts(String name, String config, String expectedMessage) throws Exception {
         ConfigParser configParser = new ConfigParser();
-        try (var kafkaProxy = new KafkaProxy(configParser, configParser.parseConfiguration(config))) {
+        try (var kafkaProxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), ProxyEnvironment.DEVELOPMENT)) {
             var illegalStateException = assertThrows(IllegalStateException.class, kafkaProxy::startup);
             assertThat(illegalStateException).hasStackTraceContaining(expectedMessage);
         }
@@ -121,7 +121,7 @@ class KafkaProxyTest {
         ConfigParser configParser = new ConfigParser();
         final Configuration parsedConfiguration = configParser.parseConfiguration(config);
         var illegalStateException = assertThrows(IllegalStateException.class, () -> {
-            try (var ignored = new KafkaProxy(configParser, parsedConfiguration)) {
+            try (var ignored = new KafkaProxy(configParser, parsedConfiguration, ProxyEnvironment.DEVELOPMENT)) {
                 fail("The proxy started, but a failure was expected.");
             }
         });

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/ProxyEnvironmentTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/ProxyEnvironmentTest.java
@@ -50,7 +50,7 @@ class ProxyEnvironmentTest {
         Configuration configuration = new Configuration(null, null, List.of(), null, false, a);
         assertThatThrownBy(() -> {
             PRODUCTION.validate(configuration);
-        }).isInstanceOf(EnvironmentConfigurationException.class).hasMessage("experimental configuration for proxy present in production mode");
+        }).isInstanceOf(EnvironmentConfigurationException.class).hasMessage("internal configuration for proxy present in production mode");
     }
 
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/ProxyEnvironmentTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/ProxyEnvironmentTest.java
@@ -28,29 +28,26 @@ class ProxyEnvironmentTest {
     static List<Arguments> permittedInternalConfigurationForEnv() {
         List<Arguments> cases = new ArrayList<>();
         cases.add(Arguments.of(DEVELOPMENT, null));
-        cases.add(Arguments.of(DEVELOPMENT, Optional.empty()));
-        cases.add(Arguments.of(DEVELOPMENT, Optional.of(Map.of())));
-        cases.add(Arguments.of(DEVELOPMENT, Optional.of(Map.of("a", "b"))));
+        cases.add(Arguments.of(DEVELOPMENT, Map.of()));
+        cases.add(Arguments.of(DEVELOPMENT, Map.of("a", "b")));
         cases.add(Arguments.of(PRODUCTION, null));
-        cases.add(Arguments.of(PRODUCTION, Optional.empty()));
-        cases.add(Arguments.of(DEVELOPMENT, Optional.of(Map.of())));
+        cases.add(Arguments.of(PRODUCTION, Map.of()));
         return cases;
     }
 
     @ParameterizedTest
     @MethodSource
-    void permittedInternalConfigurationForEnv(ProxyEnvironment env, Optional<Map<String, Object>> internalConfiguration) {
-        Configuration configuration = new Configuration(null, null, List.of(), null, false, internalConfiguration);
+    void permittedInternalConfigurationForEnv(ProxyEnvironment env, Map<String, Object> internalConfiguration) {
+        Configuration configuration = new Configuration(null, null, List.of(), null, false, Optional.ofNullable(internalConfiguration));
         assertThat(env.validate(configuration)).isEqualTo(configuration);
     }
 
     @Test
-    void invalidInternalConfigurationForProduction() {
-        Optional<Map<String, Object>> a = Optional.of(Map.of("a", "b"));
-        Configuration configuration = new Configuration(null, null, List.of(), null, false, a);
+    void nonEmptyInternalDisallowedForProduction() {
+        Configuration configuration = new Configuration(null, null, List.of(), null, false, Optional.of(Map.of("a", "b")));
         assertThatThrownBy(() -> {
             PRODUCTION.validate(configuration);
-        }).isInstanceOf(EnvironmentConfigurationException.class).hasMessage("internal configuration for proxy present in production mode");
+        }).isInstanceOf(EnvironmentConfigurationException.class).hasMessage("internal configuration for proxy present in production environment");
     }
 
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/ProxyEnvironmentTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/ProxyEnvironmentTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.kroxylicious.proxy.config.Configuration;
+
+import static io.kroxylicious.proxy.ProxyEnvironment.DEVELOPMENT;
+import static io.kroxylicious.proxy.ProxyEnvironment.PRODUCTION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProxyEnvironmentTest {
+
+    static List<Arguments> permittedInternalConfigurationForEnv() {
+        List<Arguments> cases = new ArrayList<>();
+        cases.add(Arguments.of(DEVELOPMENT, null));
+        cases.add(Arguments.of(DEVELOPMENT, Optional.empty()));
+        cases.add(Arguments.of(DEVELOPMENT, Optional.of(Map.of())));
+        cases.add(Arguments.of(DEVELOPMENT, Optional.of(Map.of("a", "b"))));
+        cases.add(Arguments.of(PRODUCTION, null));
+        cases.add(Arguments.of(PRODUCTION, Optional.empty()));
+        cases.add(Arguments.of(DEVELOPMENT, Optional.of(Map.of())));
+        return cases;
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void permittedInternalConfigurationForEnv(ProxyEnvironment env, Optional<Map<String, Object>> internalConfiguration) {
+        Configuration configuration = new Configuration(null, null, List.of(), null, false, internalConfiguration);
+        assertThat(env.validate(configuration)).isEqualTo(configuration);
+    }
+
+    @Test
+    void invalidInternalConfigurationForProduction() {
+        Optional<Map<String, Object>> a = Optional.of(Map.of("a", "b"));
+        Configuration configuration = new Configuration(null, null, List.of(), null, false, a);
+        assertThatThrownBy(() -> {
+            PRODUCTION.validate(configuration);
+        }).isInstanceOf(EnvironmentConfigurationException.class).hasMessage("experimental configuration for proxy present in production mode");
+    }
+
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -400,7 +400,7 @@ class ConfigParserTest {
 
     @Test
     void shouldThrowWhenSerializingUnserializableObject() {
-        var config = new Configuration(null, null, List.of(new FilterDefinition("", new NonSerializableConfig(""))), null, false);
+        var config = new Configuration(null, null, List.of(new FilterDefinition("", new NonSerializableConfig(""))), null, false, null);
 
         ConfigParser cp = new ConfigParser();
         assertThatThrownBy(() -> {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -210,12 +211,31 @@ class ConfigParserTest {
         assertThat(provider.type()).isEqualTo("PortPerBrokerClusterNetworkAddressConfigProvider");
         assertThat(provider.config()).isInstanceOf(PortPerBrokerClusterNetworkAddressConfigProviderConfig.class);
         assertThat(((PortPerBrokerClusterNetworkAddressConfigProviderConfig) provider.config()).getBootstrapAddress()).isEqualTo(HostPort.parse("localhost:9192"));
+        assertThat(configuration.internal()).isEmpty();
     }
 
     @Test
     void testConfigParserBadJson() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> configParser.parseConfiguration("}"));
         assertThat(exception.getMessage()).contains("Couldn't parse configuration");
+    }
+
+    @Test
+    void testConfigParserInternalOmitted() {
+        Configuration configuration = configParser.parseConfiguration("{}");
+        assertThat(configuration.internal()).isEmpty();
+    }
+
+    @Test
+    void testConfigParserInternalNull() {
+        Configuration configuration = configParser.parseConfiguration("{\"internal\": null}");
+        assertThat(configuration.internal()).isEmpty();
+    }
+
+    @Test
+    void testConfigParserInternalSpecified() {
+        Configuration configuration = configParser.parseConfiguration("{\"internal\": {\"a\":\"b\"}}}");
+        assertThat(configuration.internal()).contains(Map.of("a", "b"));
     }
 
     @SuppressWarnings("resource")
@@ -400,7 +420,7 @@ class ConfigParserTest {
 
     @Test
     void shouldThrowWhenSerializingUnserializableObject() {
-        var config = new Configuration(null, null, List.of(new FilterDefinition("", new NonSerializableConfig(""))), null, false, null);
+        var config = new Configuration(null, null, List.of(new FilterDefinition("", new NonSerializableConfig(""))), null, false, Optional.empty());
 
         ConfigParser cp = new ConfigParser();
         assertThatThrownBy(() -> {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -494,7 +494,7 @@ class KafkaProxyFrontendHandlerTest {
         while ((outboundMessage = outboundChannel.readOutbound()) != null) {
             assertThat(outboundMessage).isNotNull();
             ArrayList<Object> objects = new ArrayList<>();
-            new KafkaRequestDecoder(RequestDecoderTest.DECODE_EVERYTHING, DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES).decode(
+            new KafkaRequestDecoder(RequestDecoderTest.DECODE_EVERYTHING, DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES, new ApiVersionsServiceImpl()).decode(
                     outboundChannel.pipeline().firstContext(),
                     outboundMessage, objects);
             assertThat(objects).hasSize(1);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -494,7 +494,8 @@ class KafkaProxyFrontendHandlerTest {
         while ((outboundMessage = outboundChannel.readOutbound()) != null) {
             assertThat(outboundMessage).isNotNull();
             ArrayList<Object> objects = new ArrayList<>();
-            new KafkaRequestDecoder(RequestDecoderTest.DECODE_EVERYTHING, DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES).decode(outboundChannel.pipeline().firstContext(),
+            new KafkaRequestDecoder(RequestDecoderTest.DECODE_EVERYTHING, DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES).decode(
+                    outboundChannel.pipeline().firstContext(),
                     outboundMessage, objects);
             assertThat(objects).hasSize(1);
             if (objects.get(0) instanceof DecodedRequestFrame<?> f) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -42,6 +42,7 @@ import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.filter.NetFilter;
+import io.kroxylicious.proxy.internal.filter.ApiVersionsDowngradeFilter;
 import io.kroxylicious.proxy.internal.filter.ApiVersionsIntersectFilter;
 import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.VirtualClusterBinding;
@@ -297,7 +298,7 @@ class KafkaProxyInitializerTest {
         ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
         final KafkaProxyInitializer.InitalizerNetFilter initalizerNetFilter = new KafkaProxyInitializer.InitalizerNetFilter(mock(SaslDecodePredicate.class),
                 channel, vcb, pfr, fcf, (virtualCluster1, upstreamNodes) -> null,
-                new ApiVersionsIntersectFilter(apiVersionsService));
+                new ApiVersionsIntersectFilter(apiVersionsService), new ApiVersionsDowngradeFilter(apiVersionsService));
         final NetFilter.NetFilterContext netFilterContext = mock(NetFilter.NetFilterContext.class);
 
         // When

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -42,6 +42,7 @@ import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.filter.NetFilter;
+import io.kroxylicious.proxy.internal.filter.ApiVersionsIntersectFilter;
 import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.VirtualClusterBinding;
 import io.kroxylicious.proxy.internal.net.VirtualClusterBindingResolver;
@@ -121,7 +122,7 @@ class KafkaProxyInitializerTest {
                 (endpoint, sniHostname) -> bindingStage,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
         // When
         kafkaProxyInitializer.initChannel(channel);
 
@@ -141,7 +142,7 @@ class KafkaProxyInitializerTest {
                 virtualClusterBindingResolver,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
         when(channelPipeline.addLast(plainChannelResolverCaptor.capture())).thenReturn(channelPipeline);
 
         kafkaProxyInitializer.initChannel(channel);
@@ -165,7 +166,7 @@ class KafkaProxyInitializerTest {
                 virtualClusterBindingResolver,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
         when(channelPipeline.addLast(plainChannelResolverCaptor.capture())).thenReturn(channelPipeline);
 
         kafkaProxyInitializer.initChannel(channel);
@@ -190,7 +191,7 @@ class KafkaProxyInitializerTest {
                 (endpoint, sniHostname) -> bindingStage,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
 
         // When
         kafkaProxyInitializer.addHandlers(channel, vcb);
@@ -215,7 +216,7 @@ class KafkaProxyInitializerTest {
                 (endpoint, sniHostname) -> bindingStage,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
 
         // When
         kafkaProxyInitializer.addHandlers(channel, vcb);
@@ -236,7 +237,7 @@ class KafkaProxyInitializerTest {
                 (endpoint, sniHostname) -> bindingStage,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
 
         // When
         kafkaProxyInitializer.addHandlers(channel, vcb);
@@ -258,7 +259,7 @@ class KafkaProxyInitializerTest {
                 (endpoint, sniHostname) -> bindingStage,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of(KafkaAuthnHandler.SaslMechanism.PLAIN, plainHandler));
+                Map.of(KafkaAuthnHandler.SaslMechanism.PLAIN, plainHandler), new ApiVersionsServiceImpl());
 
         // When
         kafkaProxyInitializer.addHandlers(channel, vcb);
@@ -279,7 +280,7 @@ class KafkaProxyInitializerTest {
                 (endpoint, sniHostname) -> bindingStage,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
 
         // When
         kafkaProxyInitializer.addHandlers(channel, vcb);
@@ -293,8 +294,10 @@ class KafkaProxyInitializerTest {
         // Given
         final FilterChainFactory fcf = mock(FilterChainFactory.class);
         when(vcb.upstreamTarget()).thenReturn(new HostPort("upstream.broker.kafka", 9090));
+        ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
         final KafkaProxyInitializer.InitalizerNetFilter initalizerNetFilter = new KafkaProxyInitializer.InitalizerNetFilter(mock(SaslDecodePredicate.class),
-                mock(ApiVersionsServiceImpl.class), channel, vcb, pfr, fcf, (virtualCluster1, upstreamNodes) -> null);
+                channel, vcb, pfr, fcf, (virtualCluster1, upstreamNodes) -> null,
+                new ApiVersionsIntersectFilter(apiVersionsService));
         final NetFilter.NetFilterContext netFilterContext = mock(NetFilter.NetFilterContext.class);
 
         // When
@@ -313,7 +316,7 @@ class KafkaProxyInitializerTest {
                 (endpoint, sniHostname) -> bindingStage,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
 
         // When
         kafkaProxyInitializer.initChannel(channel);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoderTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.codec;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.protocol.types.RawTaggedField;
+import org.junit.jupiter.api.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderException;
+
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.internal.ApiVersionsServiceImpl;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class KafkaRequestDecoderTest {
+
+    @Test
+    void decodeUnknownApiVersionsRespectsOverridenLatestVersion() {
+        short latestSupportedApiVersionsOverride = (short) 2;
+        ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl(Map.of(ApiKeys.API_VERSIONS, latestSupportedApiVersionsOverride));
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(new KafkaRequestDecoder(RequestDecoderTest.DECODE_EVERYTHING, 1024, apiVersionsService));
+        RequestHeaderData header = latestVersionHeaderWithAllFields(ApiKeys.API_VERSIONS, (short) (latestSupportedApiVersionsOverride + 1));
+        byte[] arbitraryBodyBytes = new byte[]{ 1, 2, 3, 4 };
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        short latestApiVersion = ApiKeys.API_VERSIONS.latestVersion(true);
+        short requestHeaderVersion = ApiKeys.API_VERSIONS.requestHeaderVersion(latestApiVersion);
+        int headerSize = header.size(cache, requestHeaderVersion);
+        int messageSize = headerSize + arbitraryBodyBytes.length;
+        ByteBuf buffer = Unpooled.buffer();
+        ByteBufAccessorImpl accessor = new ByteBufAccessorImpl(buffer);
+        accessor.writeInt(messageSize);
+        header.write(accessor, cache, requestHeaderVersion);
+        accessor.writeByteArray(arbitraryBodyBytes);
+        embeddedChannel.writeInbound(buffer);
+        Object inboundMessage = embeddedChannel.readInbound();
+        assertThat(inboundMessage).isInstanceOfSatisfying(DecodedRequestFrame.class, decodedRequestFrame -> {
+            assertThat(decodedRequestFrame.correlationId()).isEqualTo(2);
+            assertThat(decodedRequestFrame.apiKey()).isEqualTo(ApiKeys.API_VERSIONS);
+            assertThat(decodedRequestFrame.apiVersion()).isEqualTo((short) 0);
+            assertThat(decodedRequestFrame.decodeResponse()).isTrue();
+            assertThat(decodedRequestFrame.hasResponse()).isTrue();
+            assertThat(decodedRequestFrame.header()).isInstanceOfSatisfying(RequestHeaderData.class, requestHeaderData -> {
+                assertThat(requestHeaderData.correlationId()).isEqualTo(2);
+                assertThat(requestHeaderData.requestApiKey()).isEqualTo(ApiKeys.API_VERSIONS.id);
+                assertThat(requestHeaderData.requestApiVersion()).isEqualTo((short) 0);
+                assertThat(requestHeaderData.clientId()).isEmpty();
+                assertThat(requestHeaderData.unknownTaggedFields()).isEmpty();
+                short version = ApiKeys.API_VERSIONS.requestHeaderVersion((short) 0);
+                assertUnwritable(requestHeaderData, cache, version);
+            });
+            assertThat(decodedRequestFrame.body()).isInstanceOfSatisfying(ApiVersionsRequestData.class, apiVersionsRequestData -> {
+                assertUnwritable(apiVersionsRequestData, cache, (short) 0);
+            });
+        });
+    }
+
+    @Test
+    void decodeUnknownApiVersions() {
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(new KafkaRequestDecoder(RequestDecoderTest.DECODE_EVERYTHING, 1024, new ApiVersionsServiceImpl()));
+        RequestHeaderData header = latestVersionHeaderWithAllFields(ApiKeys.API_VERSIONS, Short.MAX_VALUE);
+        byte[] arbitraryBodyBytes = new byte[]{ 1, 2, 3, 4 };
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        short latestApiVersion = ApiKeys.API_VERSIONS.latestVersion(true);
+        short requestHeaderVersion = ApiKeys.API_VERSIONS.requestHeaderVersion(latestApiVersion);
+        int headerSize = header.size(cache, requestHeaderVersion);
+        int messageSize = headerSize + arbitraryBodyBytes.length;
+        ByteBuf buffer = Unpooled.buffer();
+        ByteBufAccessorImpl accessor = new ByteBufAccessorImpl(buffer);
+        accessor.writeInt(messageSize);
+        header.write(accessor, cache, requestHeaderVersion);
+        accessor.writeByteArray(arbitraryBodyBytes);
+        embeddedChannel.writeInbound(buffer);
+        Object inboundMessage = embeddedChannel.readInbound();
+        assertThat(inboundMessage).isInstanceOfSatisfying(DecodedRequestFrame.class, decodedRequestFrame -> {
+            assertThat(decodedRequestFrame.correlationId()).isEqualTo(2);
+            assertThat(decodedRequestFrame.apiKey()).isEqualTo(ApiKeys.API_VERSIONS);
+            assertThat(decodedRequestFrame.apiVersion()).isEqualTo((short) 0);
+            assertThat(decodedRequestFrame.decodeResponse()).isTrue();
+            assertThat(decodedRequestFrame.hasResponse()).isTrue();
+            assertThat(decodedRequestFrame.header()).isInstanceOfSatisfying(RequestHeaderData.class, requestHeaderData -> {
+                assertThat(requestHeaderData.correlationId()).isEqualTo(2);
+                assertThat(requestHeaderData.requestApiKey()).isEqualTo(ApiKeys.API_VERSIONS.id);
+                assertThat(requestHeaderData.requestApiVersion()).isEqualTo((short) 0);
+                assertThat(requestHeaderData.clientId()).isEmpty();
+                assertThat(requestHeaderData.unknownTaggedFields()).isEmpty();
+                short version = ApiKeys.API_VERSIONS.requestHeaderVersion((short) 0);
+                assertUnwritable(requestHeaderData, cache, version);
+            });
+            assertThat(decodedRequestFrame.body()).isInstanceOfSatisfying(ApiVersionsRequestData.class, apiVersionsRequestData -> {
+                assertUnwritable(apiVersionsRequestData, cache, (short) 0);
+            });
+        });
+    }
+
+    // after ApiVersions negotiation we should never encounter a request from the client for an api version unknown to the proxy
+    @Test
+    void throwsOnUnsupportedVersionOfNonApiVersionsRequests() {
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(new KafkaRequestDecoder(RequestDecoderTest.DECODE_EVERYTHING, 1024, new ApiVersionsServiceImpl()));
+        short maxSupportedVersion = ApiKeys.METADATA.latestVersion(true);
+        short unsupportedVersion = (short) (maxSupportedVersion + 1);
+        RequestHeaderData header = latestVersionHeaderWithAllFields(ApiKeys.METADATA, unsupportedVersion);
+        byte[] arbitraryBodyBytes = new byte[]{ 1, 2, 3, 4 };
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        short requestHeaderVersion = ApiKeys.METADATA.requestHeaderVersion(maxSupportedVersion);
+        int headerSize = header.size(cache, requestHeaderVersion);
+        int messageSize = headerSize + arbitraryBodyBytes.length;
+        ByteBuf buffer = Unpooled.buffer();
+        ByteBufAccessorImpl accessor = new ByteBufAccessorImpl(buffer);
+        accessor.writeInt(messageSize);
+        header.write(accessor, cache, requestHeaderVersion);
+        accessor.writeByteArray(arbitraryBodyBytes);
+        assertThatThrownBy(() -> {
+            embeddedChannel.writeInbound(buffer);
+        }).isInstanceOf(DecoderException.class).cause().isInstanceOf(IllegalStateException.class)
+                .hasMessage("client apiVersion %d ahead of proxy maximum %d for api key: METADATA", unsupportedVersion, maxSupportedVersion);
+    }
+
+    private static @NonNull RequestHeaderData latestVersionHeaderWithAllFields(ApiKeys requestApiKey, short requestApiVersion) {
+        RequestHeaderData header = new RequestHeaderData();
+        header.setRequestApiKey(requestApiKey.id);
+        header.setRequestApiVersion(requestApiVersion);
+        header.setCorrelationId(2);
+        header.setClientId("clientId");
+        header.unknownTaggedFields().add(new RawTaggedField(5, "arbitrary".getBytes(StandardCharsets.UTF_8)));
+        return header;
+    }
+
+    private static void assertUnwritable(ApiMessage requestHeaderData, ObjectSerializationCache cache, short version) {
+        assertThatThrownBy(() -> requestHeaderData.size(cache, version)).isInstanceOf(UnsupportedOperationException.class);
+        ByteBufAccessorImpl byteBufAccessor = new ByteBufAccessorImpl(Unpooled.buffer());
+        assertThatThrownBy(() -> requestHeaderData.write(byteBufAccessor, cache, version)).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
@@ -306,7 +306,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
         assertEquals(45,
                 exactlyOneFrame_encoded(produceVersion,
                         ApiKeys.PRODUCE::requestHeaderVersion,
-                        (x) -> header,
+                        x -> header,
                         () -> body,
                         getKafkaRequestDecoder(DECODE_NOTHING, DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES),
                         OpaqueRequestFrame.class,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
@@ -31,6 +31,7 @@ import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.OpaqueRequestFrame;
+import io.kroxylicious.proxy.internal.ApiVersionsServiceImpl;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -92,7 +93,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
                                         .forFilters(FilterAndInvoker.build(
                                                 (ApiVersionsRequestFilter) (version, header, request, context) -> context.requestFilterResultBuilder()
                                                         .forward(header, request).completed())),
-                                DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES),
+                                DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES, new ApiVersionsServiceImpl()),
                         DecodedRequestFrame.class,
                         (RequestHeaderData header) -> header, true),
                 "Unexpected correlation id");
@@ -173,7 +174,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
                                                                                                      FilterContext context) {
                                         return context.requestFilterResultBuilder().forward(header, request).completed();
                                     }
-                                })), DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES),
+                                })), DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES, new ApiVersionsServiceImpl()),
                         OpaqueRequestFrame.class, true),
                 "Unexpected correlation id");
     }
@@ -195,7 +196,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
                         FilterAndInvoker.build((ApiVersionsRequestFilter) (version, header, request, context) -> {
                             return context.requestFilterResultBuilder().forward(header, request).completed();
                         })),
-                DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES)
+                DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES, new ApiVersionsServiceImpl())
                 .decode(null, byteBuf, messages);
 
         assertEquals(List.of(), messageClasses(messages));
@@ -227,7 +228,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
     private static KafkaRequestDecoder getKafkaRequestDecoder(DecodePredicate predicate, int socketFrameMaxSizeBytes) {
         return new KafkaRequestDecoder(
                 predicate,
-                socketFrameMaxSizeBytes);
+                socketFrameMaxSizeBytes, new ApiVersionsServiceImpl());
     }
 
     @ParameterizedTest
@@ -269,7 +270,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
                         FilterAndInvoker
                                 .build((ApiVersionsRequestFilter) (version, head, request, context) -> context.requestFilterResultBuilder().forward(header, request)
                                         .completed())),
-                DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES)
+                DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES, new ApiVersionsServiceImpl())
                 .decode(null, byteBuf, messages);
 
         assertEquals(List.of(DecodedRequestFrame.class, DecodedRequestFrame.class), messageClasses(messages));

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/ApiVersionsDowngradeFilterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/ApiVersionsDowngradeFilterTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.internal.ApiVersionsServiceImpl;
+import io.kroxylicious.proxy.internal.FilterHarness;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ApiVersionsDowngradeFilterTest extends FilterHarness {
+
+    public static final ObjectSerializationCache CACHE = new ObjectSerializationCache();
+
+    @Test
+    void shortCircuitDowngradeApiVersionsRequests() {
+        buildChannel(new ApiVersionsDowngradeFilter(new ApiVersionsServiceImpl()));
+        writeRequest(ApiVersionsDowngradeFilter.downgradeApiVersionsFrame(5));
+        DecodedResponseFrame<ApiVersionsResponseData> response = channel.readInbound();
+        assertThat(response.body()).isInstanceOfSatisfying(ApiVersionsResponseData.class, apiVersionsResponseData -> {
+            assertThat(apiVersionsResponseData.errorCode()).isEqualTo(Errors.UNSUPPORTED_VERSION.code());
+            ApiVersionsResponseData.ApiVersion apiVersion = new ApiVersionsResponseData.ApiVersion();
+            apiVersion.setApiKey(ApiKeys.API_VERSIONS.id);
+            apiVersion.setMinVersion(ApiKeys.API_VERSIONS.oldestVersion());
+            apiVersion.setMaxVersion(ApiKeys.API_VERSIONS.latestVersion(true));
+            assertThat(apiVersionsResponseData.apiKeys()).containsExactly(apiVersion);
+        });
+    }
+
+    @Test
+    void shortCircuitDowngradeApiVersionsRequestsConsidersLatestVersionOverride() {
+        buildChannel(new ApiVersionsDowngradeFilter(new ApiVersionsServiceImpl(Map.of(ApiKeys.API_VERSIONS, (short) 2))));
+        writeRequest(ApiVersionsDowngradeFilter.downgradeApiVersionsFrame(5));
+        DecodedResponseFrame<ApiVersionsResponseData> response = channel.readInbound();
+        assertThat(response.body()).isInstanceOfSatisfying(ApiVersionsResponseData.class, apiVersionsResponseData -> {
+            assertThat(apiVersionsResponseData.errorCode()).isEqualTo(Errors.UNSUPPORTED_VERSION.code());
+            ApiVersionsResponseData.ApiVersion apiVersion = new ApiVersionsResponseData.ApiVersion();
+            apiVersion.setApiKey(ApiKeys.API_VERSIONS.id);
+            apiVersion.setMinVersion(ApiKeys.API_VERSIONS.oldestVersion());
+            apiVersion.setMaxVersion((short) 2);
+            assertThat(apiVersionsResponseData.apiKeys()).containsExactly(apiVersion);
+        });
+    }
+
+    @Test
+    void passThroughAnythingElse() {
+        buildChannel(new ApiVersionsDowngradeFilter(new ApiVersionsServiceImpl()));
+        DecodedRequestFrame<ApiVersionsRequestData> request = writeRequest(new ApiVersionsRequestData());
+        var propagated = channel.readOutbound();
+        assertThat(propagated).isEqualTo(request);
+    }
+
+    @Test
+    void downgradeFrameHeaderNotWritable() {
+        DecodedRequestFrame<ApiVersionsRequestData> frame = ApiVersionsDowngradeFilter.downgradeApiVersionsFrame(5);
+        RequestHeaderData header = frame.header();
+        assertThatThrownBy(() -> header.size(CACHE, (short) 1)).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> header.write(new ByteBufferAccessor(ByteBuffer.allocate(1)), CACHE, (short) 1)).isInstanceOf(
+                UnsupportedOperationException.class);
+    }
+
+    @Test
+    void downgradeFrameBodyNotWritable() {
+        DecodedRequestFrame<ApiVersionsRequestData> frame = ApiVersionsDowngradeFilter.downgradeApiVersionsFrame(5);
+        ApiVersionsRequestData body = frame.body();
+        assertThatThrownBy(() -> body.size(CACHE, (short) 1)).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> body.write(new ByteBufferAccessor(ByteBuffer.allocate(1)), CACHE, (short) 1)).isInstanceOf(
+                UnsupportedOperationException.class);
+    }
+}


### PR DESCRIPTION
End to end test verifying a two stage downgrade actually works.

uses an old broker (redpanda) which supports only api-versions 0..2.